### PR TITLE
Handle arguments of arbitrary complexity

### DIFF
--- a/bench/load.cr
+++ b/bench/load.cr
@@ -44,9 +44,9 @@ total = iter * count
 
 a = Time.now
 iter.times do
-  args = [] of Array(Int64)
+  args = [] of {Int64}
   count.times do |idx|
-    args << [idx]
+    args << {idx}
   end
   LoadWorker.async.perform_bulk(args)
 end

--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -122,7 +122,7 @@ describe "api" do
 
       x = q.first
       x.display_class.should eq("ApiWorker")
-      x.display_args.should eq([1, "mike"])
+      x.display_args.should eq("[1,\"mike\"]")
 
       q.map(&.delete).should eq([true])
       q.size.should eq(0)
@@ -346,7 +346,7 @@ describe "api" do
 end
 
 def add_retry(jid = "bob", at = Time.now.epoch_f)
-  payload = {"class" => "ApiWorker", "args" => [1, "mike"], "queue" => "default", "jid" => jid, "retry_count" => 2, "failed_at" => Time.now.epoch_f}.to_json
+  payload = {"class" => "ApiWorker", "created_at" => Time.now.epoch_f, "args" => [1, "mike"], "queue" => "default", "jid" => jid, "retry_count" => 2, "failed_at" => Time.now.epoch_f}.to_json
   Sidekiq.redis do |conn|
     conn.zadd("retry", at.to_s, payload)
   end

--- a/spec/job_spec.cr
+++ b/spec/job_spec.cr
@@ -28,18 +28,7 @@ describe Sidekiq::Job do
         hash = JSON.parse(str).as_h
         hash.size.should eq(11)
 
-        job = Sidekiq::Job.new
-        job.load(hash)
-        aft = job.to_h
-        hash.keys.each do |key|
-          if key =~ /at/
-            hf = hash[key].as(Float64)
-            af = aft[key].as(Float64)
-            (hf * 1000).to_i64.should eq((af * 1000).to_i64)
-          else
-            hash[key].should eq(aft[key])
-          end
-        end
+        job = Sidekiq::Job.from_json(str)
       end
     end
   end

--- a/spec/retry_spec.cr
+++ b/spec/retry_spec.cr
@@ -9,7 +9,7 @@ describe "retry" do
     job = Sidekiq::Job.new
     job.queue = "default"
     job.klass = "MyWorker"
-    job.args = [1_i64] of JSON::Type
+    job.args = "1"
     rt = Sidekiq::Middleware::RetryJobs.new
 
     expect_raises do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,16 +3,6 @@ require "../src/sidekiq"
 
 POOL = Sidekiq::Pool.new
 
-# Workaround for https://github.com/crystal-lang/crystal/issues/2840
-module Sidekiq::Middleware
-  class DummyClientEntry < ClientEntry
-    def call(job, ctx, &block : -> Bool) : Bool
-      false
-    end
-  end
-end
-
-
 class MockContext < Sidekiq::Context
   getter pool
   getter logger

--- a/spec/worker_spec.cr
+++ b/spec/worker_spec.cr
@@ -37,6 +37,7 @@ describe Sidekiq::Worker do
       msg = Sidekiq.redis { |c| c.lpop("queue:default") }
       job = Sidekiq::Job.from_json(msg.as(String))
       job.args.should eq("[[{\"x\":1.0,\"y\":3.0},{\"x\":4.3,\"y\":12.5}],{\"radius\":9,\"diameter\":17}]")
+      job.execute(MockContext.new)
     end
   end
 

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -112,7 +112,7 @@ module Sidekiq
     #
     # Returns an array of the of pushed jobs' jids.  The number of jobs pushed can be less
     # than the number given if the middleware stopped processing for one or more jobs.
-    def push_bulk(job : Sidekiq::Job, allargs)
+    def push_bulk(job : Sidekiq::Job, allargs : Array(String))
       payloads = allargs.map do |args|
         copy = Sidekiq::Job.new
         copy.jid = SecureRandom.hex(12)

--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -70,6 +70,7 @@ module Sidekiq
       worker.bid = self.bid
       worker.logger = ctx.logger
       worker._perform(self.args)
+      nil
     end
 
     def _perform(args : String)

--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -22,120 +22,35 @@ module Sidekiq
       @@jobtypes[name] = klass
     end
 
-    property! queue : String
-    property! jid : String
-    property! klass : String
-    property! args : Array(JSON::Type)
-    property! created_at : Time
+    JSON.mapping({
+      queue: String,
+      jid: String,
+      klass: {type: String, key: "class"},
+      args: {type: String, converter: String::RawConverter},
+      created_at: {type: Time, converter: Sidekiq::EpochConverter},
 
-    property bid : String?
-    property at : Time?
-    property failed_at : Time?
-    property retried_at : Time?
-    property enqueued_at : Time?
-    property retry_count : Int64?
-    property error_class : String?
-    property error_message : String?
-    property error_backtrace : Array(String)?
-    property dead : Bool?
-    property backtrace : (Bool | Int64 | Nil)
-    property retry : (Bool | Int64 | Nil)
-
-    def to_h : Hash(String, JSON::Type)
-      h = Hash(String, JSON::Type).new
-      h["jid"] = jid
-      h["args"] = args
-      h["queue"] = queue
-      h["class"] = klass
-      h["created_at"] = created_at.epoch_f
-
-      h["bid"] = bid if bid
-      h["at"] = at.not_nil!.epoch_f if at
-      h["failed_at"] = failed_at.not_nil!.epoch_f if failed_at
-      h["retried_at"] = retried_at.not_nil!.epoch_f if retried_at
-      h["enqueued_at"] = enqueued_at.not_nil!.epoch_f if enqueued_at
-      h["retry_count"] = retry_count if retry_count
-      h["dead"] = dead if dead
-      h["backtrace"] = backtrace if backtrace
-      h["retry"] = retry if retry
-      h["error_class"] = error_class if error_class
-      h["error_message"] = error_message if error_message
-      h["error_backtrace"] = error_backtrace.not_nil!.map{|x| x.as(JSON::Type)} if error_backtrace
-      h
-    end
-
-    def to_json : String
-      to_h.to_json
-    end
+      at: {type: Time, converter: Sidekiq::EpochConverter, nilable: true},
+      failed_at: {type: Time, converter: Sidekiq::EpochConverter, nilable: true},
+      enqueued_at: {type: Time, converter: Sidekiq::EpochConverter, nilable: true},
+      retried_at: {type: Time, converter: Sidekiq::EpochConverter, nilable: true},
+      error_class: {type: String, nilable: true},
+      error_message: {type: String, nilable: true},
+      retry_count: {type: Int32, nilable: true},
+      bid: {type: String, nilable: true},
+      dead: {type: Bool, nilable: true},
+      error_backtrace: {type: Array(String), nilable: true},
+      backtrace: {type: (Bool | Int32 | Nil), nilable: true},
+      retry: {type: (Bool | Int32 | Nil), nilable: true},
+    })
 
     def initialize
       @queue = "default"
-      @args = [] of JSON::Type
+      @args = ""
       @klass = ""
       @created_at = Time.now.to_utc
       @enqueued_at = nil
       @jid = SecureRandom.hex(12)
       @retry = true
-    end
-
-    def load(hash : Hash(String, JSON::Type))
-      self.queue = hash["queue"].to_s
-      self.klass = hash["class"].to_s
-      self.args = hash["args"].as(Array(JSON::Type))
-      self.jid = hash["jid"].to_s
-      self.bid = hash["bid"]?.try &.to_s
-      self.error_class = hash["error_class"]?.try &.to_s
-      self.error_message = hash["error_message"]?.try &.to_s
-
-      x = hash["backtrace"]?
-      if x && x.is_a?(Int64)
-        self.backtrace = x.as(Int64)
-      elsif x && x.is_a?(Bool)
-        self.backtrace = x.as(Bool)
-      elsif x
-        raise "Invalid 'backtrace' value: #{x.inspect} / #{x.class.name}"
-      else
-        self.backtrace = nil
-      end
-
-      x = hash["retry"]?
-      if x && x.is_a?(Int64)
-        self.retry = x.as(Int64)
-      elsif x && x.is_a?(Bool)
-        self.retry = x.as(Bool)
-      elsif x
-        raise "Invalid 'retry' value: #{x.inspect} / #{x.class.name}"
-      else
-        self.retry = nil
-      end
-
-      self.retry_count = hash["retry_count"]?.try &.as(Int64)
-      self.dead = hash["dead"]?.try &.as(Bool)
-      if hash["at"]?
-        x = hash["at"].as(Float64)
-        self.at = Time.epoch_ms((x * 1000).to_i64)
-      end
-      if hash["enqueued_at"]?
-        x = hash["enqueued_at"].as(Float64)
-        self.enqueued_at = Time.epoch_ms((x * 1000).to_i64)
-      end
-      if hash["created_at"]?
-        x = hash["created_at"].as(Float64)
-        self.created_at = Time.epoch_ms((x * 1000).to_i64)
-      end
-      if hash["retried_at"]?
-        x = hash["retried_at"].as(Float64)
-        self.retried_at = Time.epoch_ms((x * 1000).to_i64)
-      end
-      if hash["failed_at"]?
-        x = hash["failed_at"].as(Float64)
-        self.failed_at = Time.epoch_ms((x * 1000).to_i64)
-      end
-
-      x = hash["error_backtrace"]?
-      if x && x.is_a?(Array)
-        self.error_backtrace = x.as(Array).map{|y| y.as(String) }
-      end
     end
 
     def client
@@ -154,55 +69,25 @@ module Sidekiq
       worker.jid = self.jid
       worker.bid = self.bid
       worker.logger = ctx.logger
-      worker._perform(args)
+      worker._perform(self.args)
     end
 
-    def _perform(*args)
-      coer = [] of JSON::Type
-      args.each { |x| coer << x.as(JSON::Type) }
-
-      @args = coer
+    def _perform(args : String)
+      @args = args
       client.push(self)
     end
 
-    def _perform_bulk(*args)
-      coer = [] of Array(JSON::Type)
-      args.each do |x|
-        foo = [] of JSON::Type
-        x.each do |arg|
-          foo << arg.as(JSON::Type)
-        end
-        coer << foo
-      end
-      client.push_bulk(self, coer)
-    end
-
-    def _perform_bulk(args : Array(Array(JSON::Type)))
-      coer = [] of Array(JSON::Type)
-      args.each do |x|
-        foo = [] of JSON::Type
-        x.each do |arg|
-          foo << arg.as(JSON::Type)
-        end
-        coer << foo
-      end
-      client.push_bulk(self, coer)
-    end
-
     # Run this job at or after the given instant in Time
-    def _perform_at(interval : Time, *args)
-      perform_in(interval.epoch_f, *args)
+    def _perform_at(interval : Time, args : String)
+      perform_in(interval.epoch_f, args)
     end
 
     # Run this job +interval+ from now.
-    def _perform_in(interval : Time::Span, *args)
+    def _perform_in(interval : Time::Span, args : String)
       now = Time.now
       ts = now + interval
 
-      coer = [] of JSON::Type
-      args.each { |x| coer << x.as(JSON::Type) }
-
-      @args = coer
+      @args = args
       @at = ts if ts > now
 
       client.push(self)

--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -78,6 +78,10 @@ module Sidekiq
       client.push(self)
     end
 
+    def _perform_bulk(args : Array(String))
+      client.push_bulk(self, args)
+    end
+
     # Run this job at or after the given instant in Time
     def _perform_at(interval : Time, args : String)
       perform_in(interval.epoch_f, args)

--- a/src/sidekiq/server/processor.cr
+++ b/src/sidekiq/server/processor.cr
@@ -95,9 +95,7 @@ module Sidekiq
       jobstr = work.job
       ack = false
       begin
-        hash = JSON.parse(jobstr)
-        job = Sidekiq::Job.new
-        job.load(hash.as_h)
+        job = Sidekiq::Job.from_json(jobstr)
 
         stats(job, jobstr) do
           @mgr.server_middleware.invoke(job, Sidekiq::Client.default_context.not_nil!) do

--- a/src/sidekiq/server/retry_jobs.cr
+++ b/src/sidekiq/server/retry_jobs.cr
@@ -67,10 +67,10 @@ module Sidekiq
       end
 
       # The retries option can be true, false, nil or Int64.
-      def retries(retry : JSON::Type)
+      def retries(retry)
         if retry.is_a?(Bool)
           retry.as(Bool) ? DEFAULT_MAX_RETRY_ATTEMPTS : 0
-        elsif retry.is_a?(Int64)
+        elsif retry.is_a?(Int32)
           retry.to_i
         else
           0
@@ -78,10 +78,10 @@ module Sidekiq
       end
 
       # The backtrace option can be true, false, nil or Int64.
-      def traces(trace : JSON::Type)
+      def traces(trace)
         if trace.is_a?(Bool)
           trace.as(Bool) ? 1000 : 0
-        elsif trace.is_a?(Int64)
+        elsif trace.is_a?(Int32)
           trace.to_i
         else
           0
@@ -95,7 +95,7 @@ module Sidekiq
         job.error_class = exception.class.name
         count = if job.retry_count.nil?
                   job.failed_at = Time.now
-                  job.retry_count = 0_i64
+                  job.retry_count = 0
                 else
                   job.retried_at = Time.now
                   c = job.retry_count.not_nil!

--- a/src/sidekiq/web_helpers.cr
+++ b/src/sidekiq/web_helpers.cr
@@ -144,9 +144,10 @@ module Sidekiq
     end
 
     def display_args(args, truncate_after_chars = 2000)
-      args.map do |arg|
-        h(truncate(to_display(arg), truncate_after_chars))
-      end.join(", ")
+      h args[1..-2]
+      #args.map do |arg|
+        #h(truncate(to_display(arg), truncate_after_chars))
+      #end.join(", ")
     end
 
     def csrf_tag

--- a/src/sidekiq/worker.cr
+++ b/src/sidekiq/worker.cr
@@ -66,6 +66,7 @@ module Sidekiq
           class PerformProxy < Sidekiq::Job
             \{% args_list = a_def.args.join(", ").id %}
             \{% args = a_def.args.map { |a| a.name }.join(", ").id %}
+            \{% res = a_def.args.map { |a| a.restriction }.join(", ").id %}
 
             def perform(\{{args_list}})
               data = ""
@@ -74,6 +75,11 @@ module Sidekiq
               \{% end %}
               _perform(data)
             end
+            \{% if a_def.args.size > 0 %}
+              def perform_bulk(argses : Array({\{{res}}}))
+                _perform_bulk(argses.map {|(\{{args}})| ARGS_TUPLE.new(\{{args}}).to_json })
+              end
+            \{% end %}
             def perform_at(interval : Time, \{{args_list}})
               data = ""
               \{% if a_def.args.size > 0 %}


### PR DESCRIPTION
This seems to work amazingly well.  `perform` arguments can now be of any type as long as they declare how to map them onto JSON.  Serializes down to basic arrays and hashes, deserializes to an arbitrary nesting of typed objects.

```ruby
class Point
  JSON.mapping({x: Float64, y: Float64})
  def initialize(@x, @y)
  end
end

class Circle
  JSON.mapping({radius: Int32, diameter: Int32})
  def initialize(@radius, @diameter)
  end
end

class ComplexWorker
  include Sidekiq::Worker

  def perform(points : Array(Point), circle : Circle)
  end
end

describe Sidekiq::Worker do
  describe "arguments" do
    it "handles arbitrary complexity" do
      p1 = Point.new(1.0, 3.0)
      p2 = Point.new(4.3, 12.5)
      a = [p1, p2]

      ComplexWorker.async.perform(a, Circle.new(9, 17))
      msg = Sidekiq.redis { |c| c.lpop("queue:default") }
      job = Sidekiq::Job.from_json(msg.as(String))
      job.args.should eq("[[{\"x\":1.0,\"y\":3.0},{\"x\":4.3,\"y\":12.5}],{\"radius\":9,\"diameter\":17}]")
    end
  end
```