### PR TITLE
Fixing middleware removal, adding spec for that

### DIFF
--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -21,6 +21,15 @@ describe "Sidekiq::Server" do
     s.server_middleware.entries.size.should eq(3)
   end
 
+  it "allows removing middleware" do
+    s = Sidekiq::Server.new
+    s.server_middleware.entries.size.should eq(2)
+    s.server_middleware.entries[0].should be_a(Sidekiq::Middleware::Logger)
+    s.server_middleware.remove(Sidekiq::Middleware::Logger)
+    s.server_middleware.entries.size.should eq(1)
+    s.server_middleware.entries[0].should be_a(Sidekiq::Middleware::RetryJobs)
+  end
+
   it "will stop" do
     s = Sidekiq::Server.new
     s.stopping?.should be_false

--- a/src/sidekiq/middleware.cr
+++ b/src/sidekiq/middleware.cr
@@ -37,7 +37,7 @@ module Sidekiq
       end
 
       def remove(klass)
-        entries.delete_if { |entry| entry.klass == klass }
+        entries.reject! { |entry| entry.class == klass }
       end
 
       def add(klass)


### PR DESCRIPTION
`Middleware#remove` doesn't work now, as crystal Array lacks a `#delete_if` method. Replacing it with `#reject!` and adding a spec for it.  (https://crystal-lang.org/api/0.18.7/Array.html) 