### PR TITLE
Fix reenqueing of jobs when server is stopped

### DIFF
--- a/spec/sidekiq/server/fetch_spec.cr
+++ b/spec/sidekiq/server/fetch_spec.cr
@@ -1,0 +1,16 @@
+require "../../spec_helper"
+require "../../../src/sidekiq/server/fetch"
+
+describe Sidekiq::BasicFetch do
+  describe "#bulk_requeue" do
+    it "reenqueue jobs" do
+      ctx = MockContext.new
+      job = Sidekiq::Job.new
+      unit_of_work = Sidekiq::BasicFetch::UnitOfWork.new("default", job.to_json, ctx)
+      fetcher = Sidekiq::BasicFetch.new ["default"]
+      fetcher.bulk_requeue ctx, [unit_of_work]
+      msg = Sidekiq.redis { |c| c.lpop("queue:default") }
+      msg.should eq job.to_json
+    end
+  end
+end

--- a/src/sidekiq/server/fetch.cr
+++ b/src/sidekiq/server/fetch.cr
@@ -81,9 +81,12 @@ module Sidekiq
 
       count = 0
       ctx.pool.redis do |conn|
-        conn.pipelined do
+        conn.pipelined do |pipeline|
           jobs_to_requeue.each do |queue, jobs|
-            conn.rpush("queue:#{queue}", jobs)
+            jobs.each do |job|
+              # Crystal-Redis sends array as one value, we are unable to do rpush("queue", jobs)
+              pipeline.rpush("queue:#{queue}", job)
+            end
             count += jobs.size
           end
         end


### PR DESCRIPTION
If you stop sidekiq when something still in progress and it unable to finish in timely manner I get next error:
```
2016-10-08T13:23:29.028Z 60216 TID-1zo2irk  INFO: Sidekiq v0.6.0 in Crystal 0.19.3
2016-10-08T13:23:29.029Z 60216 TID-1zo2irk  INFO: Licensed for use under the terms of the GNU LGPL-3.0 license.
2016-10-08T13:23:29.029Z 60216 TID-1zo2irk  INFO: Upgrade to Sidekiq Enterprise for more features and support: http://sidekiq.org
2016-10-08T13:23:29.029Z 60216 TID-1zo2irk  INFO: Starting processing with 25 workers
2016-10-08T13:23:29.029Z 60216 TID-1zo2irk  INFO: Press Ctrl-C to stop
2016-10-08T13:23:29.043Z 60216 TID-1zo2i68  JID=95520bc5b6ddbcd4a366da75 INFO: Start
^C2016-10-08T13:23:41.760Z 60216 TID-1zo2irk  INFO: Re-enqueuing 1 busy jobs
RedisError: We are in a pipelined block - call methods on the pipeline block argument instead of the Redis object (Redis::Error)
[4328195970] *CallStack::unwind:Array(Pointer(Void)) +82
[4328195873] *CallStack#initialize:Array(Pointer(Void)) +17
[4328195832] *CallStack::new:CallStack +40
[4328167337] *raise<Redis::Error>:NoReturn +25
[4329056023] *Redis::Strategy::PauseDuringPipeline#command<Array(String)>:NoReturn +39
[4328933771] *Redis#command<Array(String)>:(Array(Redis::RedisValue) | Int64 | String | Nil) +427
[4328935352] *Redis@Redis::CommandExecution::ValueOriented#integer_command<Array(String)>:Int64 +40
[4328938611] *Redis@Redis::Commands#rpush<String, Array(String)>:Int64 +179
[4329063179] *Sidekiq::BasicFetch#bulk_requeue<Sidekiq::Server, Array(Sidekiq::UnitOfWork+)>:Int32 +843
[4328976999] *Sidekiq::CLI#run<Sidekiq::Server>:NoReturn +1847
[4328056213] __crystal_main +2645
[4328115992] main +40
```

I just make redis call to a pipeline instead of direct connection.
I also send job one by one to `rpush`, because `rpush` doesn't support array as argument and serialize array as string, which leads to broken job in redis.