### PR TITLE
Fix defaults for worker without args

### DIFF
--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -45,7 +45,7 @@ module Sidekiq
 
     def initialize
       @queue = "default"
-      @args = ""
+      @args = "[]"
       @klass = ""
       @created_at = Time.now.to_utc
       @enqueued_at = nil

--- a/src/sidekiq/worker.cr
+++ b/src/sidekiq/worker.cr
@@ -85,7 +85,7 @@ module Sidekiq
             \{% args_list = a_def.args.join(", ").id %}
             \{% args = a_def.args.map { |a| a.name }.join(", ").id %}
             \{% res = a_def.args.map { |a| a.restriction }.join(", ").id %}
-            \{% json = (a_def.args.size > 0) ? "ARGS_TUPLE.new(#{args}).to_json".id : "" %}
+            \{% json = (a_def.args.size > 0) ? "ARGS_TUPLE.new(#{args}).to_json".id : "[]" %}
 
             def perform(\{{args_list}})
               _perform(\{{json}})


### PR DESCRIPTION
If `perform` method of worker has no arguments, I get next error:
```
WARN: {"job":"{\"queue\":\"default\",\"jid\":\"4186fd1d4926273cdfaa9116\",\"class\":\"SimpleJob\",\"args\":,\"created_at\":1476205595.1608269,\"enqueued_at\":1476205595.182435,\"retry\":true}"}
WARN: JSON::ParseException: unexpected token: , at 1:79
```
The problem is in agrs serialization: `\"args\":,\"created_at\"`