### PR TITLE
use pure crystal in hb spec

### DIFF
--- a/spec/heartbeat_spec.cr
+++ b/spec/heartbeat_spec.cr
@@ -1,3 +1,4 @@
+require "json"
 require "./spec_helper"
 require "../src/sidekiq/server/heartbeat"
 
@@ -6,10 +7,11 @@ describe Sidekiq::Heartbeat do
     svr = Sidekiq::Server.new
 
     hb = Sidekiq::Heartbeat.new
-    j = hb.server_json(svr)
-    hostname = `hostname`.strip
-    j.should match /#{hostname}/
+    json = hb.server_json(svr)
+    ret = JSON.parse json
 
-    hb.❤(svr, j)
+    ret["hostname"].should eq(System.hostname)
+
+    hb.❤(svr, json)
   end
 end


### PR DESCRIPTION
+ Use `json` parsing instead of **regexp** matching
+ Use `crystal` to get `hostname` instead of backticks 😉 