### PR TITLE
Upgrade crystal-redis to the latest version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ license: LGPL-3.0
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 1.8.0
+    version: ~> 1.9.0
   pool:
     github: ysbaddaden/pool
     version: ~> 0.2.3


### PR DESCRIPTION
First of all, thank you for your awesome work and open sourcing sidekiq.cr. I use it for my hobby project [Crystal ANN](https://crystal-ann.com/) which you may find interesting also for the announcements.

I have a conflict using this shard with [amber framework](https://github.com/amberframework/amber), because amber [uses](https://github.com/amberframework/amber/blob/ff64493a8f94e3c06941963d44f4b92926dcbaf5/shard.yml#L32-L34) a newer crystal redis shard. This tiny PR just points to the latest available crystal-redis:

https://github.com/stefanwille/crystal-redis/releases/tag/v1.9.0