### PR TITLE
Support of crystal 0.24.1

### DIFF
--- a/examples/web.cr
+++ b/examples/web.cr
@@ -3,7 +3,7 @@ require "../src/sidekiq/web"
 # Build this with `crystal compile --release web.cr
 
 Kemal::Session.config do |config|
-  # crystal eval 'require "secure_random"; puts SecureRandom.hex(64)'
+  # crystal eval 'require "random/secure"; puts Random::Secure.hex(64)'
   config.secret = "3ae480ffc18380c6afa05e96c8a2262c"
 end
 

--- a/shard.yml
+++ b/shard.yml
@@ -15,10 +15,10 @@ dependencies:
     version: ~> 0.2.3
   kemal:
     github: kemalcr/kemal
-    version: ~> 0.21.0
+    version: ~> 0.22.0
   kemal-csrf:
     github: kemalcr/kemal-csrf
-    version: ~> 0.3.0
+    version: 0.4.0
   baked_file_system:
     github: schovi/baked_file_system
     version: ~> 0.9.4

--- a/spec/retry_spec.cr
+++ b/spec/retry_spec.cr
@@ -12,7 +12,7 @@ describe "retry" do
     job.args = "1"
     rt = Sidekiq::Middleware::RetryJobs.new
 
-    expect_raises do
+    expect_raises(Exception) do
       rt.call(job, ctx) do
         raise "boom"
       end

--- a/spec/web_spec.cr
+++ b/spec/web_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 require "../src/sidekiq/web"
 
 Kemal::Session.config do |config|
-  # crystal eval 'require "secure_random"; puts SecureRandom.hex(64)'
+  # crystal eval 'require "random_secure"; puts Random::Secure.hex(64)'
   config.secret = "3ae480ffc18380c6afa05e96c8a2262c"
 end
 
@@ -463,7 +463,7 @@ private def add_scheduled
          "queue" => "default",
          "created_at" => now,
          "args"  => ["bob", 1, now],
-         "jid"   => SecureRandom.hex(12)}
+         "jid"   => Random::Secure.hex(12)}
   score = now.to_s
   Sidekiq.redis do |conn|
     conn.zadd("schedule", score, msg.to_json)
@@ -482,7 +482,7 @@ private def add_retry
     "retry_count"   => 0,
     "retried_at"    => now,
     "failed_at"     => now,
-    "jid"           => SecureRandom.hex(12)}
+    "jid"           => Random::Secure.hex(12)}
   score = now.to_s
   Sidekiq.redis do |conn|
     conn.zadd("retry", score, msg.to_json)
@@ -501,7 +501,7 @@ private def add_dead
     "retry_count"   => 20,
     "retried_at"    => now,
     "failed_at"     => now,
-    "jid"           => SecureRandom.hex(12)}
+    "jid"           => Random::Secure.hex(12)}
   score = now.to_s
   Sidekiq.redis do |conn|
     conn.zadd("dead", score, msg.to_json)
@@ -519,7 +519,7 @@ private def add_xss_retry
     "error_class"   => "RuntimeError",
     "retry_count"   => 0,
     "failed_at"     => now,
-    "jid"           => SecureRandom.hex(12)}
+    "jid"           => Random::Secure.hex(12)}
   score = now.to_s
   Sidekiq.redis do |conn|
     conn.zadd("retry", score, msg.to_json)

--- a/src/sidekiq/api.cr
+++ b/src/sidekiq/api.cr
@@ -163,7 +163,7 @@ module Sidekiq
         dates = [] of String
 
         while i < @days_previous
-          date = @start_date - i
+          date = @start_date - i.milliseconds
           datestr = date.to_s("%Y-%m-%d")
           keys << "stat:#{stat}:#{datestr}"
           dates << datestr

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -1,4 +1,4 @@
-require "secure_random"
+require "random/secure"
 require "./types"
 
 module Sidekiq
@@ -125,7 +125,7 @@ module Sidekiq
     def push_bulk(job : Sidekiq::Job, allargs : Array(String))
       payloads = allargs.map do |args|
         copy = Sidekiq::Job.new
-        copy.jid = SecureRandom.hex(12)
+        copy.jid = Random::Secure.hex(12)
         copy.klass = job.klass
         copy.queue = job.queue
         copy.args = args

--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -2,7 +2,6 @@ require "json"
 require "./core_ext"
 
 module Sidekiq
-
   ##
   # The Job class handles the internal business of converting
   # to/from JSON.  In a statically-typed language, this is
@@ -49,7 +48,7 @@ module Sidekiq
       @klass = ""
       @created_at = Time.now.to_utc
       @enqueued_at = nil
-      @jid = SecureRandom.hex(12)
+      @jid = Random::Secure.hex(12)
       @retry = true
     end
 

--- a/src/sidekiq/server/heartbeat.cr
+++ b/src/sidekiq/server/heartbeat.cr
@@ -1,4 +1,4 @@
-require "secure_random"
+require "random/secure"
 require "./util"
 
 module Sidekiq

--- a/src/sidekiq/server/server.cr
+++ b/src/sidekiq/server/server.cr
@@ -25,7 +25,7 @@ module Sidekiq
     def initialize(@environment = "development", @queues = ["default"],
                    @concurrency = 25, @logger = Sidekiq::Logger.build)
       @hostname = ENV["DYNO"]? || System.hostname
-      nonce = SecureRandom.hex(6)
+      nonce = Random::Secure.hex(6)
       @identity = "#{@hostname}:#{::Process.pid}:#{nonce}"
       @busy = 0
       @tag = ""


### PR DESCRIPTION
Crystal 0.24.1 is out https://github.com/crystal-lang/crystal/releases/tag/v0.24.1

This PR is about to fix compatibility issues.

Upgraded dependencies:

* kemal https://github.com/kemalcr/kemal/releases/tag/v0.22.0
* keaml-csrf https://github.com/kemalcr/kemal-csrf/releases/tag/v0.4.0
  
Could you please prepare a new release once it is merged?