### PR TITLE
Port number_with_delimiter method from ActiveSupport

### DIFF
--- a/spec/web_helpers_spec.cr
+++ b/spec/web_helpers_spec.cr
@@ -1,0 +1,22 @@
+require "./spec_helper"
+
+class ClassWithWebHelpers
+  include Sidekiq::WebHelpers
+end
+
+describe Sidekiq::WebHelpers do
+  describe "#number_with_delimiter" do
+    it "returns formatted number with delimiter" do
+      klass = ClassWithWebHelpers.new
+
+      klass.number_with_delimiter(1).should eq "1"
+      klass.number_with_delimiter(123).should eq "123"
+      klass.number_with_delimiter(1234).should eq "1,234"
+      klass.number_with_delimiter(12345).should eq "12,345"
+      klass.number_with_delimiter(123456).should eq "123,456"
+      klass.number_with_delimiter(1234567).should eq "1,234,567"
+      klass.number_with_delimiter(12345678).should eq "12,345,678"
+      klass.number_with_delimiter(123456789).should eq "123,456,789"
+    end
+  end
+end

--- a/src/sidekiq/web_helpers.cr
+++ b/src/sidekiq/web_helpers.cr
@@ -135,9 +135,9 @@ module Sidekiq
 
     def display_args(args, truncate_after_chars = 2000)
       h args[1..-2]
-      #args.map do |arg|
-        #h(truncate(to_display(arg), truncate_after_chars))
-      #end.join(", ")
+      # args.map do |arg|
+      # h(truncate(to_display(arg), truncate_after_chars))
+      # end.join(", ")
     end
 
     def csrf_tag
@@ -172,7 +172,7 @@ module Sidekiq
     end
 
     def number_with_delimiter(number)
-      number.to_s
+      number.to_s.gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1,")
     end
 
     def h(text)


### PR DESCRIPTION
https://github.com/rails/rails/blob/cfb1e4dfd8813d3d5c75a15a750b3c53eebdea65/activesupport/lib/active_support/number_helper/number_to_delimited_converter.rb
https://github.com/crystal-lang/crystal/issues/5573

---

![sidekiq_crystal](https://user-images.githubusercontent.com/1527612/37701056-ea067df6-2ced-11e8-8be4-f97b6eab7de9.gif)

This inconsistency between frontend and backend was driving me mad 😅 

Comments (138-140) modified by crystal's autoformatter, I can revert if needed.