### PR TITLE
Fix redirect location after deleting queue

### DIFF
--- a/src/sidekiq/web.cr
+++ b/src/sidekiq/web.cr
@@ -123,7 +123,7 @@ end
 post "/queues/:name" do |x|
   name = x.params.url["name"]
   Sidekiq::Queue.new(name).clear
-  x.redirect "#{x.root_path}/queues"
+  x.redirect "#{x.root_path}queues"
 end
 
 post "/queues/:name/delete" do |x|


### PR DESCRIPTION
This solves invalid redirect to something like `https://queues/` in your browser after removing queue (due to double slash location)

Style modified by crystal's autoformatter, I can revert if needed.