### PR TITLE
Register busy count based on Processor's worker_state

### DIFF
--- a/spec/heartbeat_spec.cr
+++ b/spec/heartbeat_spec.cr
@@ -14,4 +14,25 @@ describe Sidekiq::Heartbeat do
 
     hb.❤(svr, json)
   end
+
+  it "registers number of busy workers based on Processor's worker_state" do
+    svr = Sidekiq::Server.new
+    hb = Sidekiq::Heartbeat.new
+
+    json = hb.server_json(svr)
+
+    Sidekiq.redis do |conn|
+      hb.❤(svr, json)
+      conn.hget(svr.identity, "busy").should eq("0")
+    end
+
+    processor = Sidekiq::Processor.new(svr)
+
+    processor.stats(Sidekiq::Job.new) do
+      hb.❤(svr, json)
+      Sidekiq.redis do |conn|
+        conn.hget(svr.identity, "busy").should eq("1")
+      end
+    end
+  end
 end

--- a/spec/sidekiq_spec.cr
+++ b/spec/sidekiq_spec.cr
@@ -65,15 +65,19 @@ describe Sidekiq do
     end
 
     it "allows a redis provider" do
-      ENV["REDIS_PROVIDER"] = "FOO_URL"
-      ENV["FOO_URL"] = "redis://:xyzzy@acmecorp.com:1234/14"
+      begin
+        ENV["REDIS_PROVIDER"] = "FOO_URL"
+        ENV["FOO_URL"] = "redis://:xyzzy@acmecorp.com:1234/14"
 
-      r = Sidekiq::RedisConfig.new
-      r.hostname.should eq("acmecorp.com")
-      r.port.should eq(1234)
-      r.password.should eq("xyzzy")
-      r.db.should eq(14)
-      r.pool_size.should eq(5)
+        r = Sidekiq::RedisConfig.new
+        r.hostname.should eq("acmecorp.com")
+        r.port.should eq(1234)
+        r.password.should eq("xyzzy")
+        r.db.should eq(14)
+        r.pool_size.should eq(5)
+      ensure
+        ENV["REDIS_PROVIDER"] = nil
+      end
     end
   end
 end

--- a/spec/web_helpers_spec.cr
+++ b/spec/web_helpers_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../src/sidekiq/web_helpers"
 
 class ClassWithWebHelpers
   include Sidekiq::WebHelpers

--- a/src/sidekiq/server/heartbeat.cr
+++ b/src/sidekiq/server/heartbeat.cr
@@ -78,7 +78,7 @@ module Sidekiq
           conn.multi do |multi|
             multi.sadd("processes", svr.identity)
             multi.hmset(svr.identity, {"info"  => json,
-              "busy"  => svr.busy,
+              "busy"  => Processor.worker_state.size,
               "beat"  => Time.now.epoch_f,
               "quiet" => svr.stopping?})
             multi.expire(svr.identity, 60)

--- a/src/sidekiq/server/server.cr
+++ b/src/sidekiq/server/server.cr
@@ -18,7 +18,6 @@ module Sidekiq
     getter labels : Array(String)
     getter queues : Array(String)
     getter tag : String
-    getter busy : Int32
     getter identity : String
     getter hostname : String
 
@@ -27,7 +26,6 @@ module Sidekiq
       @hostname = ENV["DYNO"]? || System.hostname
       nonce = Random::Secure.hex(6)
       @identity = "#{@hostname}:#{::Process.pid}:#{nonce}"
-      @busy = 0
       @tag = ""
       @labels = ["crystal"]
       @alive = true


### PR DESCRIPTION
Another quicky - I noticed that `busy` state was always `0` in web ui panel.

Please take a closer look at this, I'm that super familiar with internals, but it seems `busy` state should be read from Processor's `@@worker_state` and getter on `Sidekiq::Server` was never actually used ❓ 

I was looking at Ruby's original implementation to confirm what is the right/expected approach here.

https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/launcher.rb#L95-L103
https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/processor.rb#L194-L207

update: aaand let's fix introduced regression in specs, sorry about that, random execution order is random 😅 