### PR TITLE
Upgrade Redis Version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ license: LGPL-3.0
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 1.9.0
+    version: ~> 1.11.0
   pool:
     github: ysbaddaden/pool
     version: ~> 0.2.3


### PR DESCRIPTION
Why
Redis shard have release a few versions already latest version is 1.11.0

What
Updates the shard dependency file to  use latest version