### PR TITLE
Use crystal-redis 2.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ crystal: 0.25.0
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 1.11.0
+    version: ~> 2.0.0
   pool:
     github: ysbaddaden/pool
     version: ~> 0.2.3


### PR DESCRIPTION
Crystal-redis 2.0.0 has been released yesterday and it includes auto reconnecting. This should fix #58 (and I briefly checked that it really seems to do):

```
[truncated]
2018-06-21T13:54:47.594Z 10069 TID-1z87g5c  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87iio  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87gg0  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87h1c  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87h4w  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87gn4  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87hfk  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87gu8  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87hmo  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87ibk  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87if4  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87hj4  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87hc0  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:47.594Z 10069 TID-1z87gqo  ERROR: /usr/local/Cellar/crystal-lang/0.25.0_1/src/fiber.cr:29:34 in '->'
2018-06-21T13:54:52.922Z 10069 TID-1z87i4g  INFO: Redis is online, 00:00:05.442555000 sec downtime
2018-06-21T13:54:52.924Z 10069 TID-1z87gn4  INFO: Redis is online, 00:00:05.443010000 sec downtime
2018-06-21T13:54:52.924Z 10069 TID-1z87iio  INFO: Redis is online, 00:00:05.443748000 sec downtime
2018-06-21T13:54:52.924Z 10069 TID-1z87hmo  INFO: Redis is online, 00:00:05.443004000 sec downtime
2018-06-21T13:54:53.027Z 10069 TID-1z87hfk  INFO: Redis is online, 00:00:05.546474000 sec downtime
2018-06-21T13:54:53.027Z 10069 TID-1z87hj4  INFO: Redis is online, 00:00:05.546352000 sec downtime
2018-06-21T13:54:53.438Z 10069 TID-1z87i0w  INFO: Redis is online, 00:00:05.979601000 sec downtime
2018-06-21T13:54:53.542Z 10069 TID-1z87gcg  INFO: Redis is online, 00:00:06.262475000 sec downtime
2018-06-21T13:54:53.542Z 10069 TID-1z87gjk  INFO: Redis is online, 00:00:06.074877000 sec downtime
2018-06-21T13:54:54.669Z 10069 TID-1z87hc0  INFO: Redis is online, 00:00:07.187345000 sec downtime
2018-06-21T13:54:54.669Z 10069 TID-1z87gu8  INFO: Redis is online, 00:00:07.187685000 sec downtime
2018-06-21T13:54:54.773Z 10069 TID-1z87h4w  INFO: Redis is online, 00:00:07.291972000 sec downtime
2018-06-21T13:54:54.773Z 10069 TID-1z87gqo  INFO: Redis is online, 00:00:07.291553000 sec downtime
2018-06-21T13:54:54.773Z 10069 TID-1z87hq8  INFO: Redis is online, 00:00:07.293442000 sec downtime
2018-06-21T13:54:54.773Z 10069 TID-1z87ibk  INFO: Redis is online, 00:00:07.291980000 sec downtime
2018-06-21T13:54:54.773Z 10069 TID-1z87hxc  INFO: Redis is online, 00:00:07.299175000 sec downtime
2018-06-21T13:54:54.876Z 10069 TID-1z87if4  INFO: Redis is online, 00:00:07.395012000 sec downtime
2018-06-21T13:54:54.876Z 10069 TID-1z87hts  INFO: Redis is online, 00:00:07.396524000 sec downtime
2018-06-21T13:54:54.876Z 10069 TID-1z87i80  INFO: Redis is online, 00:00:07.396749000 sec downtime
2018-06-21T13:54:54.876Z 10069 TID-1z87g8w  INFO: Redis is online, 00:00:07.396905000 sec downtime
2018-06-21T13:54:54.877Z 10069 TID-1z87h1c  INFO: Redis is online, 00:00:07.396025000 sec downtime
2018-06-21T13:54:54.977Z 10069 TID-1z87gxs  INFO: Redis is online, 00:00:07.497262000 sec downtime
2018-06-21T13:54:54.977Z 10069 TID-1z87gg0  INFO: Redis is online, 00:00:07.496834000 sec downtime
2018-06-21T13:54:54.977Z 10069 TID-1z87h8g  INFO: Redis is online, 00:00:07.497431000 sec downtime
2018-06-21T13:54:54.977Z 10069 TID-1z87g5c  INFO: Redis is online, 00:00:07.497312000 sec downtime
^C2018-06-21T13:55:33.924Z 10069 TID-1z87iww  INFO: Done, bye!
```