### PR TITLE
Copy retry option when pushing bulk jobs

### DIFF
--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -129,6 +129,7 @@ module Sidekiq
         copy.klass = job.klass
         copy.queue = job.queue
         copy.args = args
+        copy.retry = job.retry
         result = middleware.invoke(copy, @ctx) do
           !!copy
         end


### PR DESCRIPTION
Previously, when using
```cr
sidekiq_options do |job|
  job.retry = false
end
```

when submitting a bulk job, the retry wouldn't be copied and jobs would be retried anyway.