### PR TITLE
Upgrade kemal-csrf-dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -23,7 +23,7 @@ dependencies:
     commit: bc720cca9c27e391b4b3fc32ae7cc23f4d3f3fdc
   kemal-csrf:
     github: kemalcr/kemal-csrf
-    version: 0.4.0
+    version: 0.5.0
   baked_file_system:
     github: schovi/baked_file_system
     version: ~> 0.9.5


### PR DESCRIPTION
I've had some issues with `shards check` reporting `kemal-session` being out of date after adding Sidekiq to my project.

## Steps to reproduce

In a clean repository, run: `shards install && shards check`.

## Expected behaviour

A clean install should report that all dependencies are satisfied.

## Actual behaviour

```
⟩ shards check
Dependencies aren't satisfied. Install them with 'shards install'
```

## Cause

It turns out that `kemal-csrf@0.4.0` requires  `kemal-session@0.9.0` while this project is referring to the commit for `kemal-session@0.10.0`. Upgrading to `kemal-csrf@0.5.0` resolves the problem.