### PR TITLE
Loose Redis version requirement

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ crystal: 0.25.0
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.0.0
+    version: ~> 2.0
   pool:
     github: ysbaddaden/pool
     version: ~> 0.2.3


### PR DESCRIPTION
The requirement `~> 2.0.0` breaks `shards install` when using newer `stefanwille/crystal-redis` versions (e.g. `2.1.1`).  Changing the requirement to `~> 2.0` resolves that. 