### PR TITLE
Fix namespace scope resolution in Sidekiq::Worker

### DIFF
--- a/spec/worker_spec.cr
+++ b/spec/worker_spec.cr
@@ -41,6 +41,15 @@ class NoArgumentsWorker
   end
 end
 
+module Worker
+  class SimpleWorker
+    include Sidekiq::Worker
+
+    def perform
+    end
+  end
+end
+
 describe Sidekiq::Worker do
   describe "arguments" do
     it "handles arbitrary complexity" do
@@ -61,6 +70,14 @@ describe Sidekiq::Worker do
       job = Sidekiq::Job.from_json(msg.as(String))
       job.args.should eq("[]")
       job.execute(MockContext.new)
+    end
+  end
+
+  describe ".async" do
+    it "does not fail to compile when name of first module is Worker" do
+      # N.B: the spec suite will not even run if this fails
+      ::Worker::SimpleWorker.async.perform
+      ::Worker::SimpleWorker.async() { }.perform
     end
   end
 

--- a/src/sidekiq/worker.cr
+++ b/src/sidekiq/worker.cr
@@ -110,7 +110,7 @@ module Sidekiq
       # no block
       def async
         {% begin %}
-        job = {{@type.id}}::PerformProxy.new
+        job = ::{{@type.id}}::PerformProxy.new
         job.klass = self.name
         Sidekiq::Worker::OPTION_BLOCKS["{{@type.id}}"]?.try &.call(job)
         job
@@ -120,7 +120,7 @@ module Sidekiq
       # if passed a block, yields the job
       def async
         {% begin %}
-        job = {{@type.id}}::PerformProxy.new
+        job = ::{{@type.id}}::PerformProxy.new
         job.klass = self.name
         Sidekiq::Worker::OPTION_BLOCKS["{{@type.id}}"]?.try &.call(job)
         yield job


### PR DESCRIPTION
Attempting to include the `Sidekiq::Worker` module and using it with a worker class inside a top-level `Worker` namespace (e.g. via `Worker::MyWorker.async.perform`) results in the following compile error:

```
in src/worker/my_worker.cr:19: instantiating 'Worker::MyWorker.class#async()'

          Worker::MyWorker.async.perform(user_id, item_id)
                                   ^~~~~

in lib/sidekiq/src/sidekiq/worker.cr:112: expanding macro

        {% begin %}
        ^

in macro 'macro_4870787408' /Users/nilsding/Projects/some_project/lib/sidekiq/src/sidekiq/worker.cr:112, line 4:

   1.
   2.
   3.
>  4.         job = Worker::MyWorker::PerformProxy.new
   5.         job.klass = self.name
   6.         Sidekiq::Worker::OPTION_BLOCKS["Worker::MyWorker"]?.try &.call(job)
   7.         job
   8.

undefined constant Worker::MyWorker::PerformProxy
```

I think this is because it tries to start resolving from the `Sidekiq` namespace, as this is the `Sidekiq::Worker` module.

Anyway, this PR fixes that.  Yay! :tada: