### PR TITLE
Fix "Live Poll" button

### DIFF
--- a/src/web/views/_poll_link.ecr
+++ b/src/web/views/_poll_link.ecr
@@ -1,5 +1,5 @@
 <% if x.current_path != "" %>
-  <% if x.params.query[:poll]? %>
+  <% if x.params.query["poll"]? == "true" %>
     <a id="live-poll" class="btn btn-primary active" href="<%= x.root_path + x.current_path %>"><%= x.t("StopPolling") %></a>
   <% else %>
     <a id="live-poll" class="btn btn-primary" href="<%= x.root_path + x.current_path %>?<%= x.qparams({poll: true}) %>"><%= x.t("LivePoll") %></a>


### PR DESCRIPTION
This PR basically changes the polling check in the `_poll_link.ecr` view to the same one as seen in `_poll_js.ecr`.  The actual fix is accessing the query parameter as a string instead of a symbol.