### PR TITLE
Crystal 0.27.0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -20,7 +20,7 @@ dependencies:
     branch: master
   kemal-session:
     github: kemalcr/kemal-session
-    commit: bc720cca9c27e391b4b3fc32ae7cc23f4d3f3fdc
+    commit: a16f164d3dcfc6e720d566f9085285abdd5b7825
   kemal-csrf:
     github: kemalcr/kemal-csrf
     version: 0.5.0

--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
 
 license: LGPL-3.0
 
-crystal: 0.25.0
+crystal: 0.27.0
 
 dependencies:
   redis:

--- a/spec/web_spec.cr
+++ b/spec/web_spec.cr
@@ -332,9 +332,9 @@ describe "sidekiq web" do
     Sidekiq.redis do |conn|
       pro = "foo:1234"
       conn.sadd("processes", pro)
-      conn.hmset(pro, {"info" => {"identity" => pro, "hostname" => "foo", "pid" => 1234, "concurrency" => 25, "started_at" => Time.now.epoch_f, "labels" => ["frumduz"], "queues" => ["default"]}.to_json, "busy" => 1, "beat" => Time.now.epoch_f})
+      conn.hmset(pro, {"info" => {"identity" => pro, "hostname" => "foo", "pid" => 1234, "concurrency" => 25, "started_at" => Time.now.to_unix_f, "labels" => ["frumduz"], "queues" => ["default"]}.to_json, "busy" => 1, "beat" => Time.now.to_unix_f})
       identity = "#{pro}:workers"
-      hash = {:queue => "critical", :payload => {"queue" => "foo", "jid" => "12355", "class" => "FailWorker", "args" => ["<a>hello</a>"], "created_at" => Time.now.epoch_f}, :run_at => Time.now.epoch}
+      hash = {:queue => "critical", :payload => {"queue" => "foo", "jid" => "12355", "class" => "FailWorker", "args" => ["<a>hello</a>"], "created_at" => Time.now.to_unix_f}, :run_at => Time.now.to_unix}
       conn.hmset(identity, {"100001" => hash.to_json})
       conn.incr("busy")
     end
@@ -466,7 +466,7 @@ describe "sidekiq web" do
 end
 
 private def add_scheduled
-  now = Time.now.epoch_f
+  now = Time.now.to_unix_f
   msg = {"class"      => "HardWorker",
          "queue"      => "default",
          "created_at" => now,
@@ -480,7 +480,7 @@ private def add_scheduled
 end
 
 private def add_retry
-  now = Time.now.epoch_f
+  now = Time.now.to_unix_f
   msg = {"class"         => "HardWorker",
          "args"          => ["bob", 1, now.to_s],
          "queue"         => "default",
@@ -499,7 +499,7 @@ private def add_retry
 end
 
 private def add_dead
-  now = Time.now.epoch_f
+  now = Time.now.to_unix_f
   msg = {"class"         => "HardWorker",
          "args"          => ["bob", 1, now],
          "queue"         => "foo",
@@ -518,7 +518,7 @@ private def add_dead
 end
 
 private def add_xss_retry
-  now = Time.now.epoch_f
+  now = Time.now.to_unix_f
   msg = {"class"         => "FailWorker",
          "args"          => ["<a>hello</a>"],
          "queue"         => "foo",
@@ -541,7 +541,7 @@ private def add_worker
   Sidekiq.redis do |conn|
     conn.multi do |m|
       m.sadd("processes", key)
-      m.hmset(key, {"info" => {"concurrency" => 25, "identity" => key, "pid" => Process.pid, "hostname" => "foo", "started_at" => Time.now.epoch_f, "queues" => ["default", "critical"]}.to_json, "beat" => Time.now.epoch_f, "busy" => 4})
+      m.hmset(key, {"info" => {"concurrency" => 25, "identity" => key, "pid" => Process.pid, "hostname" => "foo", "started_at" => Time.now.to_unix_f, "queues" => ["default", "critical"]}.to_json, "beat" => Time.now.to_unix_f, "busy" => 4})
       m.hmset("#{key}:workers", {"1001" => msg})
     end
   end

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -154,7 +154,7 @@ module Sidekiq
         all = [] of Redis::RedisValue
         payloads.each do |hash|
           at, hash.at = hash.at, nil
-          all << at.not_nil!.epoch_f.to_s
+          all << at.not_nil!.to_unix_f.to_s
           all << hash.to_json
         end
         conn.zadd("schedule", all)

--- a/src/sidekiq/core_ext.cr
+++ b/src/sidekiq/core_ext.cr
@@ -2,11 +2,11 @@ module Sidekiq
   module EpochConverter
     # https://github.com/crystal-lang/crystal/issues/2643
     def self.to_json(value : Time, builder : JSON::Builder)
-      builder.number value.epoch_f
+      builder.number value.to_unix_f
     end
 
     def self.from_json(value : JSON::PullParser) : Time
-      Time.epoch_ms((value.read_float * 1000).to_i64)
+      Time.unix_ms((value.read_float * 1000).to_i64)
     end
   end
 end

--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -83,7 +83,7 @@ module Sidekiq
 
     # Run this job at or after the given instant in Time
     def _perform_at(interval : Time, args : String)
-      perform_in(interval.epoch_f, args)
+      perform_in(interval.to_unix_ms, args)
     end
 
     # Run this job +interval+ from now.

--- a/src/sidekiq/server/heartbeat.cr
+++ b/src/sidekiq/server/heartbeat.cr
@@ -39,7 +39,7 @@ module Sidekiq
     def server_json(svr)
       data = {
         "hostname"    => svr.hostname,
-        "started_at"  => Time.now.epoch_f,
+        "started_at"  => Time.now.to_unix_ms,
         "pid"         => ::Process.pid,
         "tag"         => svr.tag,
         "concurrency" => svr.concurrency,
@@ -79,7 +79,7 @@ module Sidekiq
             multi.sadd("processes", svr.identity)
             multi.hmset(svr.identity, {"info"  => json,
                                        "busy"  => Processor.worker_state.size,
-                                       "beat"  => Time.now.epoch_f,
+                                       "beat"  => Time.now.to_unix_ms,
                                        "quiet" => svr.stopping?})
             multi.expire(svr.identity, 60)
             multi.rpop("#{svr.identity}-signals")

--- a/src/sidekiq/server/middleware.cr
+++ b/src/sidekiq/server/middleware.cr
@@ -4,10 +4,10 @@ require "./retry_jobs"
 class Sidekiq::Middleware::Logger < Sidekiq::Middleware::ServerEntry
   def call(job, ctx)
     Sidekiq::Logger.with_context("JID=#{job.jid}") do
-      a = Time.now.epoch_f
+      a = Time.now.to_unix_ms
       ctx.logger.info { "Start" }
       yield
-      ctx.logger.info { "Done: #{"%.6f" % (Time.now.epoch_f - a)} sec" }
+      ctx.logger.info { "Done: #{"%.6f" % (Time.now.to_unix_ms - a)} sec" }
       true
     end
   end

--- a/src/sidekiq/server/processor.cr
+++ b/src/sidekiq/server/processor.cr
@@ -141,7 +141,7 @@ module Sidekiq
     end
 
     def stats(job)
-      @@worker_state[@identity] = {"queue" => job.queue, "payload" => job, "run_at" => Time.now.epoch}
+      @@worker_state[@identity] = {"queue" => job.queue, "payload" => job, "run_at" => Time.now.to_unix}
 
       begin
         yield

--- a/src/sidekiq/server/retry_jobs.cr
+++ b/src/sidekiq/server/retry_jobs.cr
@@ -114,7 +114,7 @@ module Sidekiq
           retry_at = Time.now + delay.seconds
           payload = job.to_json
           ctx.pool.redis do |conn|
-            conn.zadd("retry", retry_at.epoch_f.to_s, payload)
+            conn.zadd("retry", retry_at.to_unix_ms.to_s, payload)
           end
         else
           # Goodbye dear message, you (re)tried your best I'm sure.
@@ -136,7 +136,7 @@ module Sidekiq
         now = Time.now
         ctx.pool.redis do |conn|
           conn.multi do
-            conn.zadd("dead", now.epoch_f.to_s, payload)
+            conn.zadd("dead", now.to_unix_ms.to_s, payload)
             conn.zremrangebyscore("dead", "-inf", now - 6.months)
             conn.zremrangebyrank("dead", 0, -10_000)
           end

--- a/src/sidekiq/server/scheduled.cr
+++ b/src/sidekiq/server/scheduled.cr
@@ -9,7 +9,7 @@ module Sidekiq
         # A job's "score" in Redis is the time at which it should be processed.
         # Just check Redis for the set of jobs with a timestamp before now.
         count = 0
-        nowstr = "%.6f" % now.epoch_f
+        nowstr = "%.6f" % now.to_unix_ms
         ctx.pool.redis do |conn|
           sorted_sets.each do |sorted_set|
             # Get the next item in the queue if it's score (time to execute) is <= now.

--- a/src/web/views/dashboard.ecr
+++ b/src/web/views/dashboard.ecr
@@ -39,35 +39,35 @@
   <div class="stats-container">
     <% if redis_info.fetch("redis_version", nil) %>
       <div class="stat">
-        <h3 class="redis_version"><%= redis_info.fetch("redis_version") %></h3>
+        <h3 class="redis_version"><%= redis_info.fetch("redis_version", nil) %></h3>
         <p><%= x.t("Version") %></p>
       </div>
     <% end %>
 
     <% if redis_info.fetch("uptime_in_days", nil) %>
       <div class="stat">
-        <h3 class="uptime_in_days"><%= redis_info.fetch("uptime_in_days") %></h3>
+        <h3 class="uptime_in_days"><%= redis_info.fetch("uptime_in_days", nil) %></h3>
         <p><%= x.t("Uptime") %></p>
       </div>
     <% end %>
 
     <% if redis_info.fetch("connected_clients", nil) %>
       <div class="stat">
-        <h3 class="connected_clients"><%= redis_info.fetch("connected_clients") %></h3>
+        <h3 class="connected_clients"><%= redis_info.fetch("connected_clients", nil) %></h3>
         <p><%= x.t("Connections") %></p>
       </div>
     <% end %>
 
     <%  if redis_info.fetch("used_memory_human", nil) %>
       <div class="stat">
-        <h3 class="used_memory_human"><%= redis_info.fetch("used_memory_human") %></h3>
+        <h3 class="used_memory_human"><%= redis_info.fetch("used_memory_human", nil) %></h3>
         <p><%= x.t("MemoryUsage") %></p>
       </div>
     <% end %>
 
     <%  if redis_info.fetch("used_memory_peak_human", nil) %>
       <div class="stat">
-        <h3 class="used_memory_peak_human"><%= redis_info.fetch("used_memory_peak_human") %></h3>
+        <h3 class="used_memory_peak_human"><%= redis_info.fetch("used_memory_peak_human", nil) %></h3>
         <p><%= x.t("PeakMemoryUsage") %></p>
       </div>
     <% end %>


### PR DESCRIPTION
Support for Cyrstal 0.27.0 - Latest Version

- Renamed `#epoch(sencods)` to `unix(sencods)`
- Renamed `#epoch_ms(milisencods)` to `unix_ms(milisencods)`
- Renamed `#epoch()` to `to_unix()`
- Renamed `#epoch_f()` to `to_unix_f()`
- Hash#fetch now doesn't have an overload with only one argument. 

For more details see the [changelog](https://github.com/crystal-lang/crystal/releases/tag/0.27.0)