### PR TITLE
Use to_unix_f where epoch_f was previously used

### DIFF
--- a/src/sidekiq/api.cr
+++ b/src/sidekiq/api.cr
@@ -82,7 +82,7 @@ module Sidekiq
       default_queue_latency = if (entry = pipe1_res[6].as(Array(Redis::RedisValue)).first?)
                                 hash = JSON.parse(entry.as(String))
                                 was = hash["enqueued_at"].as_f
-                                Time.now.to_unix_ms - was
+                                Time.now.to_unix_f - was
                               else
                                 0.0_f64
                               end
@@ -293,7 +293,7 @@ module Sidekiq
 
       hash = JSON.parse(msg).as_h
       was = hash["enqueued_at"].as_f
-      Time.now.to_unix_ms - was
+      Time.now.to_unix_f - was
     end
 
     def each
@@ -348,9 +348,6 @@ module Sidekiq
 
     def at
       Time.unix_ms((score * 1000).to_i64)
-    rescue ArgumentError
-      # Rescue: Invalid time: seconds out of range (ArgumentError)
-      Time.unix_ms((score.to_i32 * 1000).to_i64)
     end
 
     def delete
@@ -389,7 +386,7 @@ module Sidekiq
     def kill!
       raise "Kill not available on jobs which have not failed" unless item["failed_at"]
       remove_job do |message|
-        now = Time.now.to_unix_ms
+        now = Time.now.to_unix_f
         Sidekiq.redis do |conn|
           conn.multi do |m|
             m.zadd("dead", now, message)

--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -83,7 +83,7 @@ module Sidekiq
 
     # Run this job at or after the given instant in Time
     def _perform_at(interval : Time, args : String)
-      perform_in(interval.to_unix_ms, args)
+      perform_in(interval.to_unix_f, args)
     end
 
     # Run this job +interval+ from now.

--- a/src/sidekiq/server/heartbeat.cr
+++ b/src/sidekiq/server/heartbeat.cr
@@ -39,7 +39,7 @@ module Sidekiq
     def server_json(svr)
       data = {
         "hostname"    => svr.hostname,
-        "started_at"  => Time.now.to_unix_ms,
+        "started_at"  => Time.now.to_unix_f,
         "pid"         => ::Process.pid,
         "tag"         => svr.tag,
         "concurrency" => svr.concurrency,
@@ -79,7 +79,7 @@ module Sidekiq
             multi.sadd("processes", svr.identity)
             multi.hmset(svr.identity, {"info"  => json,
                                        "busy"  => Processor.worker_state.size,
-                                       "beat"  => Time.now.to_unix_ms,
+                                       "beat"  => Time.now.to_unix_f,
                                        "quiet" => svr.stopping?})
             multi.expire(svr.identity, 60)
             multi.rpop("#{svr.identity}-signals")

--- a/src/sidekiq/server/middleware.cr
+++ b/src/sidekiq/server/middleware.cr
@@ -4,10 +4,10 @@ require "./retry_jobs"
 class Sidekiq::Middleware::Logger < Sidekiq::Middleware::ServerEntry
   def call(job, ctx)
     Sidekiq::Logger.with_context("JID=#{job.jid}") do
-      a = Time.now.to_unix_ms
+      a = Time.now.to_unix_f
       ctx.logger.info { "Start" }
       yield
-      ctx.logger.info { "Done: #{"%.6f" % (Time.now.to_unix_ms - a)} sec" }
+      ctx.logger.info { "Done: #{"%.6f" % (Time.now.to_unix_f - a)} sec" }
       true
     end
   end

--- a/src/sidekiq/server/retry_jobs.cr
+++ b/src/sidekiq/server/retry_jobs.cr
@@ -114,7 +114,7 @@ module Sidekiq
           retry_at = Time.now + delay.seconds
           payload = job.to_json
           ctx.pool.redis do |conn|
-            conn.zadd("retry", retry_at.to_unix_ms.to_s, payload)
+            conn.zadd("retry", retry_at.to_unix_f.to_s, payload)
           end
         else
           # Goodbye dear message, you (re)tried your best I'm sure.
@@ -136,7 +136,7 @@ module Sidekiq
         now = Time.now
         ctx.pool.redis do |conn|
           conn.multi do
-            conn.zadd("dead", now.to_unix_ms.to_s, payload)
+            conn.zadd("dead", now.to_unix_f.to_s, payload)
             conn.zremrangebyscore("dead", "-inf", now - 6.months)
             conn.zremrangebyrank("dead", 0, -10_000)
           end

--- a/src/sidekiq/server/scheduled.cr
+++ b/src/sidekiq/server/scheduled.cr
@@ -9,7 +9,7 @@ module Sidekiq
         # A job's "score" in Redis is the time at which it should be processed.
         # Just check Redis for the set of jobs with a timestamp before now.
         count = 0
-        nowstr = "%.6f" % now.to_unix_ms
+        nowstr = "%.6f" % now.to_unix_f
         ctx.pool.redis do |conn|
           sorted_sets.each do |sorted_set|
             # Get the next item in the queue if it's score (time to execute) is <= now.


### PR DESCRIPTION
PR #73 provided Crystal 0.27.0 support.  Unfortunately, some occurrences of `epoch_f` were replaced with `to_unix_ms`, which was probably not intended, and made the `Busy` page (and probably other usages of the Sidekiq API in a Crystal app as well) break with an error similar to this:

```
Exception: cast from Int64 to Float+ failed, at /usr/local/Cellar/crystal/0.27.0/src/json/any.cr:189:5:189 (TypeCastError)
  from /usr/local/Cellar/crystal/0.27.0/src/json/any.cr:0:5 in 'as_f'
  from src/sidekiq/api.cr:640:21 in 'started_at'
  from src/sidekiq/web.cr:40:33 in '->'
  from lib/kemal/src/kemal/route.cr:255:3 in '->'
  from lib/kemal/src/kemal/route_handler.cr:255:3 in 'process_request'
  from lib/kemal/src/kemal/route_handler.cr:17:7 in 'call'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/handler.cr:24:7 in 'call_next'
  from lib/kemal/src/kemal/websocket_handler.cr:13:14 in 'call'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/handler.cr:24:7 in 'call_next'
  from lib/kemal-csrf/src/kemal-csrf.cr:40:12 in 'call'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/handler.cr:24:7 in 'call_next'
  from lib/kemal/src/kemal/static_file_handler.cr:67:9 in 'call'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/handler.cr:24:7 in 'call_next'
  from lib/kemal/src/kemal/exception_handler.cr:8:7 in 'call'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/handler.cr:24:7 in 'call_next'
  from lib/kemal/src/kemal/log_handler.cr:10:35 in 'call'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/handler.cr:24:7 in 'call_next'
  from lib/kemal/src/kemal/init_handler.cr:12:7 in 'call'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/request_processor.cr:39:11 in 'process'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server/request_processor.cr:16:3 in 'process'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server.cr:396:5 in 'handle_client'
  from /usr/local/Cellar/crystal/0.27.0/src/http/server.cr:362:13 in '->'
  from /usr/local/Cellar/crystal/0.27.0/src/fiber.cr:255:3 in 'run'
  from /usr/local/Cellar/crystal/0.27.0/src/fiber.cr:75:34 in '->'
```

The Ruby Sidekiq web interface would however not break on the `Busy` page and happily display the start time of the worker.  Here is a screen shot of it before this change, with two workers (one from a Rails app, the other one from Crystal) started at the same time:
<img width="819" alt="screenshot 2018-12-10 at 21 44 42" src="https://user-images.githubusercontent.com/1809170/49760516-f7717e80-fcc4-11e8-9306-369ad2410740.png">

Here is the same page after this change:
<img width="1003" alt="screenshot 2018-12-10 at 21 49 42" src="https://user-images.githubusercontent.com/1809170/49760753-88e0f080-fcc5-11e8-816a-c889389216e8.png">
