### PR TITLE
Fixes for Crystal 0.28.0 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,10 @@
 # Sidekiq.cr Changelog
 
+0.7.0
+----------
+
+- Fixes for Crystal 0.8.0 [#78]
+
 0.6.1
 ----------
 

--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 0.7.0
 ----------
 
-- Fixes for Crystal 0.8.0 [#78]
+- Fixes for Crystal 0.28.0 [#78]
 
 0.6.1
 ----------

--- a/bench/load.cr
+++ b/bench/load.cr
@@ -44,7 +44,7 @@ iter = 10
 count = 10_000_i64
 total = iter * count
 
-a = Time.now
+a = Time.utc
 iter.times do
   args = [] of {Int64}
   count.times do |idx|
@@ -52,20 +52,20 @@ iter.times do
   end
   LoadWorker.async.perform_bulk(args)
 end
-puts "Created #{count*iter} jobs in #{Time.now - a}"
+puts "Created #{count*iter} jobs in #{Time.utc - a}"
 
 require "../src/sidekiq/server"
 
 spawn do
-  a = Time.now
+  a = Time.utc
   loop do
     count = r.llen("queue:default")
     if count == 0
-      b = Time.now
+      b = Time.utc
       puts "Done in #{b - a}: #{"%.3f" % (total / (b - a).to_f)} jobs/sec".colorize(:green)
       exit
     end
-    p [Time.now, count, Process.rss]
+    p [Time.utc, count, Process.rss]
     sleep 0.2
   end
 end

--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ authors:
 
 license: LGPL-3.0
 
-crystal: 0.27.0
+crystal: 0.28.0
 
 dependencies:
   redis:

--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -166,7 +166,7 @@ describe "api" do
     end
 
     it "can fetch by score" do
-      same_time = Time.now.to_unix_f
+      same_time = Time.utc.to_unix_f
       add_retry("bob1", same_time)
       add_retry("bob2", same_time)
       r = Sidekiq::RetrySet.new
@@ -174,7 +174,7 @@ describe "api" do
     end
 
     it "can fetch by score and jid" do
-      same_time = Time.now.to_unix_f
+      same_time = Time.utc.to_unix_f
       add_retry("bob1", same_time)
       add_retry("bob2", same_time)
       r = Sidekiq::RetrySet.new
@@ -198,11 +198,11 @@ describe "api" do
       retri.klass.should eq("ApiWorker")
       retri.queue.should eq("default")
       retri.jid.should eq("bob")
-      Time.now.to_unix_f.should be_close(retri.at.to_unix_f, 0.02)
+      Time.utc.to_unix_f.should be_close(retri.at.to_unix_f, 0.02)
     end
 
     it "can delete a single retry from score and jid" do
-      same_time = Time.now.to_unix_f
+      same_time = Time.utc.to_unix_f
       add_retry("bob1", same_time)
       add_retry("bob2", same_time)
       r = Sidekiq::RetrySet.new
@@ -251,10 +251,10 @@ describe "api" do
         "hostname"   => JSON::Any.new(System.hostname),
         "key"        => JSON::Any.new(identity_string),
         "identity"   => JSON::Any.new(identity_string),
-        "started_at" => JSON::Any.new(Time.now.to_unix_f - 15),
+        "started_at" => JSON::Any.new(Time.utc.to_unix_f - 15),
       }
 
-      time = Time.now.to_unix_f
+      time = Time.utc.to_unix_f
       Sidekiq.redis do |conn|
         conn.multi do |m|
           m.sadd("processes", odata["key"])
@@ -282,14 +282,14 @@ describe "api" do
 
       hn = System.hostname
       key = "#{hn}:#{Process.pid}"
-      pdata = {"pid" => Process.pid, "hostname" => hn, "started_at" => Time.now.to_unix}
+      pdata = {"pid" => Process.pid, "hostname" => hn, "started_at" => Time.utc.to_unix}
       Sidekiq.redis do |conn|
         conn.sadd("processes", key)
-        conn.hmset(key, {"info" => pdata.to_json, "busy" => 0, "beat" => Time.now.to_unix_f})
+        conn.hmset(key, {"info" => pdata.to_json, "busy" => 0, "beat" => Time.utc.to_unix_f})
       end
 
       s = "#{key}:workers"
-      data = {"payload" => "{}", "queue" => "default", "run_at" => Time.now.to_unix}.to_json
+      data = {"payload" => "{}", "queue" => "default", "run_at" => Time.utc.to_unix}.to_json
       Sidekiq.redis do |c|
         c.hmset(s, {"1234" => data})
       end
@@ -299,7 +299,7 @@ describe "api" do
         entry.process_id.should eq(key)
         entry.thread_id.should eq("1234")
         entry.work["queue"].should eq("default")
-        Time.unix(entry.work["run_at"].as_i).year.should eq(Time.now.year)
+        Time.unix(entry.work["run_at"].as_i).year.should eq(Time.utc.year)
         count += 1
       end
       count.should eq(1)
@@ -311,22 +311,22 @@ describe "api" do
 
       retries = Sidekiq::RetrySet.new
       retries.size.should eq(2)
-      retries.select { |r| r.score > (Time.now.to_unix_f + 9) }.size.should eq(0)
+      retries.select { |r| r.score > (Time.utc.to_unix_f + 9) }.size.should eq(0)
 
       retries.each do |retri|
-        retri.reschedule(Time.now.to_unix_f + 10) if retri.jid == "foo2"
+        retri.reschedule(Time.utc.to_unix_f + 10) if retri.jid == "foo2"
       end
 
       retries.size.should eq(2)
-      retries.select { |r| r.score > (Time.now.to_unix_f + 9) }.size.should eq(1)
+      retries.select { |r| r.score > (Time.utc.to_unix_f + 9) }.size.should eq(1)
     end
 
     it "prunes processes which have died" do
-      data = {"pid" => rand(10_000), "hostname" => "app#{rand(1_000)}", "started_at" => Time.now.to_unix_f}
+      data = {"pid" => rand(10_000), "hostname" => "app#{rand(1_000)}", "started_at" => Time.utc.to_unix_f}
       key = "#{data["hostname"]}:#{data["pid"]}"
       Sidekiq.redis do |conn|
         conn.sadd("processes", key)
-        conn.hmset(key, {"info" => data.to_json, "busy" => 0, "beat" => Time.now.to_unix_f})
+        conn.hmset(key, {"info" => data.to_json, "busy" => 0, "beat" => Time.utc.to_unix_f})
       end
 
       ps = Sidekiq::ProcessSet.new
@@ -345,8 +345,8 @@ describe "api" do
   end
 end
 
-def add_retry(jid = "bob", at = Time.now.to_unix_f)
-  payload = {"class" => "ApiWorker", "created_at" => Time.now.to_unix_f, "args" => [1, "mike"], "queue" => "default", "jid" => jid, "retry_count" => 2, "failed_at" => Time.now.to_unix_f}.to_json
+def add_retry(jid = "bob", at = Time.utc.to_unix_f)
+  payload = {"class" => "ApiWorker", "created_at" => Time.utc.to_unix_f, "args" => [1, "mike"], "queue" => "default", "jid" => jid, "retry_count" => 2, "failed_at" => Time.utc.to_unix_f}.to_json
   Sidekiq.redis do |conn|
     conn.zadd("retry", at.to_s, payload)
   end

--- a/spec/compat_spec.cr
+++ b/spec/compat_spec.cr
@@ -10,7 +10,7 @@ describe "ruby compatibility" do
         rs.size.should eq(1)
         rs.each do |retri|
           retri.queue.should eq("foo")
-          retri.at.should be < Time.now
+          retri.at.should be < Time.local
         end
       end
     end

--- a/spec/sidekiq_spec.cr
+++ b/spec/sidekiq_spec.cr
@@ -19,7 +19,7 @@ describe Sidekiq do
 
   describe "pool" do
     it "works" do
-      t = Time.now
+      t = Time.local
       pool = ConnectionPool.new { Redis.new }
       pool.connection do |conn|
         conn.set("foo", t)

--- a/spec/stats_spec.cr
+++ b/spec/stats_spec.cr
@@ -14,8 +14,8 @@ describe Sidekiq::Stats do
     end
 
     it "returns correct data from redis" do
-      yesterday = (Time.now.to_utc.at_beginning_of_day - 1.day).to_s("%Y-%m-%d")
-      today = Time.now.to_utc.at_beginning_of_day.to_s("%Y-%m-%d")
+      yesterday = (Time.utc.at_beginning_of_day - 1.day).to_s("%Y-%m-%d")
+      today = Time.utc.at_beginning_of_day.to_s("%Y-%m-%d")
 
       Sidekiq.redis do |redis|
         redis.set("stat:failed:#{yesterday}", 42)

--- a/spec/stats_spec.cr
+++ b/spec/stats_spec.cr
@@ -14,8 +14,8 @@ describe Sidekiq::Stats do
     end
 
     it "returns correct data from redis" do
-      yesterday = (Time.now.to_utc.date - 1.day).to_s("%Y-%m-%d")
-      today = Time.now.to_utc.date.to_s("%Y-%m-%d")
+      yesterday = (Time.now.to_utc.at_beginning_of_day - 1.day).to_s("%Y-%m-%d")
+      today = Time.now.to_utc.at_beginning_of_day.to_s("%Y-%m-%d")
 
       Sidekiq.redis do |redis|
         redis.set("stat:failed:#{yesterday}", 42)

--- a/spec/web_spec.cr
+++ b/spec/web_spec.cr
@@ -332,9 +332,9 @@ describe "sidekiq web" do
     Sidekiq.redis do |conn|
       pro = "foo:1234"
       conn.sadd("processes", pro)
-      conn.hmset(pro, {"info" => {"identity" => pro, "hostname" => "foo", "pid" => 1234, "concurrency" => 25, "started_at" => Time.now.to_unix_f, "labels" => ["frumduz"], "queues" => ["default"]}.to_json, "busy" => 1, "beat" => Time.now.to_unix_f})
+      conn.hmset(pro, {"info" => {"identity" => pro, "hostname" => "foo", "pid" => 1234, "concurrency" => 25, "started_at" => Time.utc.to_unix_f, "labels" => ["frumduz"], "queues" => ["default"]}.to_json, "busy" => 1, "beat" => Time.utc.to_unix_f})
       identity = "#{pro}:workers"
-      hash = {:queue => "critical", :payload => {"queue" => "foo", "jid" => "12355", "class" => "FailWorker", "args" => ["<a>hello</a>"], "created_at" => Time.now.to_unix_f}, :run_at => Time.now.to_unix}
+      hash = {:queue => "critical", :payload => {"queue" => "foo", "jid" => "12355", "class" => "FailWorker", "args" => ["<a>hello</a>"], "created_at" => Time.utc.to_unix_f}, :run_at => Time.utc.to_unix}
       conn.hmset(identity, {"100001" => hash.to_json})
       conn.incr("busy")
     end
@@ -466,7 +466,7 @@ describe "sidekiq web" do
 end
 
 private def add_scheduled
-  now = Time.now.to_unix_f
+  now = Time.utc.to_unix_f
   msg = {"class"      => "HardWorker",
          "queue"      => "default",
          "created_at" => now,
@@ -480,7 +480,7 @@ private def add_scheduled
 end
 
 private def add_retry
-  now = Time.now.to_unix_f
+  now = Time.utc.to_unix_f
   msg = {"class"         => "HardWorker",
          "args"          => ["bob", 1, now.to_s],
          "queue"         => "default",
@@ -499,7 +499,7 @@ private def add_retry
 end
 
 private def add_dead
-  now = Time.now.to_unix_f
+  now = Time.utc.to_unix_f
   msg = {"class"         => "HardWorker",
          "args"          => ["bob", 1, now],
          "queue"         => "foo",
@@ -518,7 +518,7 @@ private def add_dead
 end
 
 private def add_xss_retry
-  now = Time.now.to_unix_f
+  now = Time.utc.to_unix_f
   msg = {"class"         => "FailWorker",
          "args"          => ["<a>hello</a>"],
          "queue"         => "foo",
@@ -541,7 +541,7 @@ private def add_worker
   Sidekiq.redis do |conn|
     conn.multi do |m|
       m.sadd("processes", key)
-      m.hmset(key, {"info" => {"concurrency" => 25, "identity" => key, "pid" => Process.pid, "hostname" => "foo", "started_at" => Time.now.to_unix_f, "queues" => ["default", "critical"]}.to_json, "beat" => Time.now.to_unix_f, "busy" => 4})
+      m.hmset(key, {"info" => {"concurrency" => 25, "identity" => key, "pid" => Process.pid, "hostname" => "foo", "started_at" => Time.utc.to_unix_f, "queues" => ["default", "critical"]}.to_json, "beat" => Time.utc.to_unix_f, "busy" => 4})
       m.hmset("#{key}:workers", {"1001" => msg})
     end
   end

--- a/src/sidekiq/api.cr
+++ b/src/sidekiq/api.cr
@@ -145,7 +145,7 @@ module Sidekiq
 
       def initialize(days_previous, start_date = nil)
         @days_previous = days_previous
-        @start_date = start_date || Time.now.to_utc.date
+        @start_date = start_date || Time.now.to_utc.at_beginning_of_day
       end
 
       def processed

--- a/src/sidekiq/api.cr
+++ b/src/sidekiq/api.cr
@@ -82,7 +82,7 @@ module Sidekiq
       default_queue_latency = if (entry = pipe1_res[6].as(Array(Redis::RedisValue)).first?)
                                 hash = JSON.parse(entry.as(String))
                                 was = hash["enqueued_at"].as_f
-                                Time.now.to_unix_f - was
+                                Time.utc.to_unix_f - was
                               else
                                 0.0_f64
                               end
@@ -145,7 +145,7 @@ module Sidekiq
 
       def initialize(days_previous, start_date = nil)
         @days_previous = days_previous
-        @start_date = start_date || Time.now.to_utc.at_beginning_of_day
+        @start_date = start_date || Time.utc.at_beginning_of_day
       end
 
       def processed
@@ -209,7 +209,7 @@ module Sidekiq
     end
 
     def latency
-      (Time.now.to_utc - (enqueued_at || created_at)).to_f
+      (Time.utc - (enqueued_at || created_at)).to_f
     end
 
     # #
@@ -293,7 +293,7 @@ module Sidekiq
 
       hash = JSON.parse(msg).as_h
       was = hash["enqueued_at"].as_f
-      Time.now.to_unix_f - was
+      Time.utc.to_unix_f - was
     end
 
     def each
@@ -386,7 +386,7 @@ module Sidekiq
     def kill!
       raise "Kill not available on jobs which have not failed" unless item["failed_at"]
       remove_job do |message|
-        now = Time.now.to_unix_f
+        now = Time.utc.to_unix_f
         Sidekiq.redis do |conn|
           conn.multi do |m|
             m.zadd("dead", now, message)

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -160,7 +160,7 @@ module Sidekiq
         conn.zadd("schedule", all)
       else
         q = payloads.first.queue
-        now = Time.now
+        now = Time.utc
         to_push = payloads.map do |entry|
           entry.enqueued_at = now
           entry.to_json

--- a/src/sidekiq/job.cr
+++ b/src/sidekiq/job.cr
@@ -46,7 +46,7 @@ module Sidekiq
       @queue = "default"
       @args = "[]"
       @klass = ""
-      @created_at = Time.now.to_utc
+      @created_at = Time.utc
       @enqueued_at = nil
       @jid = Random::Secure.hex(12)
       @retry = true
@@ -88,7 +88,7 @@ module Sidekiq
 
     # Run this job +interval+ from now.
     def _perform_in(interval : Time::Span, args : String)
-      now = Time.now
+      now = Time.utc
       ts = now + interval
 
       @args = args

--- a/src/sidekiq/server/cli.cr
+++ b/src/sidekiq/server/cli.cr
@@ -70,12 +70,12 @@ module Sidekiq
       channel = Channel(Int32).new
 
       Signal::INT.trap do
-        shutdown_started_at = Time.now
+        shutdown_started_at = Time.utc
         svr.request_stop
         channel.send 0
       end
       Signal::TERM.trap do
-        shutdown_started_at = Time.now
+        shutdown_started_at = Time.utc
         svr.request_stop
         channel.send 0
       end
@@ -88,7 +88,7 @@ module Sidekiq
       channel.receive
 
       deadline = shutdown_started_at.not_nil! + @timeout.seconds
-      while Time.now < deadline && !svr.processors.empty?
+      while Time.utc < deadline && !svr.processors.empty?
         sleep 0.1
       end
 

--- a/src/sidekiq/server/heartbeat.cr
+++ b/src/sidekiq/server/heartbeat.cr
@@ -39,7 +39,7 @@ module Sidekiq
     def server_json(svr)
       data = {
         "hostname"    => svr.hostname,
-        "started_at"  => Time.now.to_unix_f,
+        "started_at"  => Time.utc.to_unix_f,
         "pid"         => ::Process.pid,
         "tag"         => svr.tag,
         "concurrency" => svr.concurrency,
@@ -58,7 +58,7 @@ module Sidekiq
         procd, fails = Processor.fetch_counts
 
         workers_key = "#{svr.identity}:workers"
-        nowdate = @daily.format(Time.now.to_utc)
+        nowdate = @daily.format(Time.utc)
         svr.pool.redis do |conn|
           conn.multi do |multi|
             multi.incrby("stat:processed", procd)
@@ -79,7 +79,7 @@ module Sidekiq
             multi.sadd("processes", svr.identity)
             multi.hmset(svr.identity, {"info"  => json,
                                        "busy"  => Processor.worker_state.size,
-                                       "beat"  => Time.now.to_unix_f,
+                                       "beat"  => Time.utc.to_unix_f,
                                        "quiet" => svr.stopping?})
             multi.expire(svr.identity, 60)
             multi.rpop("#{svr.identity}-signals")

--- a/src/sidekiq/server/middleware.cr
+++ b/src/sidekiq/server/middleware.cr
@@ -4,10 +4,10 @@ require "./retry_jobs"
 class Sidekiq::Middleware::Logger < Sidekiq::Middleware::ServerEntry
   def call(job, ctx)
     Sidekiq::Logger.with_context("JID=#{job.jid}") do
-      a = Time.now.to_unix_f
+      a = Time.utc.to_unix_f
       ctx.logger.info { "Start" }
       yield
-      ctx.logger.info { "Done: #{"%.6f" % (Time.now.to_unix_f - a)} sec" }
+      ctx.logger.info { "Done: #{"%.6f" % (Time.utc.to_unix_f - a)} sec" }
       true
     end
   end

--- a/src/sidekiq/server/processor.cr
+++ b/src/sidekiq/server/processor.cr
@@ -62,7 +62,7 @@ module Sidekiq
     def get_one
       begin
         work = @mgr.fetcher.retrieve_work(@mgr)
-        (@mgr.logger.info { "Redis is online, #{Time.now - @down.not_nil!} sec downtime" }; @down = nil) if @down
+        (@mgr.logger.info { "Redis is online, #{Time.utc - @down.not_nil!} sec downtime" }; @down = nil) if @down
         work
       rescue ex
         handle_fetch_exception(ex)
@@ -81,7 +81,7 @@ module Sidekiq
 
     def handle_fetch_exception(ex)
       if !@down
-        @down = Time.now
+        @down = Time.utc
         @mgr.logger.error("Error fetching job: #{ex}")
         ex.backtrace.each do |bt|
           @mgr.logger.error(bt)
@@ -141,7 +141,7 @@ module Sidekiq
     end
 
     def stats(job)
-      @@worker_state[@identity] = {"queue" => job.queue, "payload" => job, "run_at" => Time.now.to_unix}
+      @@worker_state[@identity] = {"queue" => job.queue, "payload" => job, "run_at" => Time.utc.to_unix}
 
       begin
         yield

--- a/src/sidekiq/server/scheduled.cr
+++ b/src/sidekiq/server/scheduled.cr
@@ -5,7 +5,7 @@ module Sidekiq
     SETS = %w(retry schedule)
 
     class Enq
-      def enqueue_jobs(ctx, now = Time.now, sorted_sets = SETS)
+      def enqueue_jobs(ctx, now = Time.utc, sorted_sets = SETS)
         # A job's "score" in Redis is the time at which it should be processed.
         # Just check Redis for the set of jobs with a timestamp before now.
         count = 0

--- a/src/web/views/_footer.ecr
+++ b/src/web/views/_footer.ecr
@@ -9,7 +9,7 @@
             <p class="navbar-text redis-url" title="<%= x.redis_location %>"><%= x.redis_location %></p>
           </li>
           <li>
-            <p class="navbar-text"><%= Time.now.to_utc.to_s("%H:%M:%S UTC") %></p>
+            <p class="navbar-text"><%= Time.utc.to_s("%H:%M:%S UTC") %></p>
           </li>
         </ul>
     </div>


### PR DESCRIPTION
In which I replace every occurrence of `Time.now` with `Time.utc` (or `Time.local`) because time zones are a horrible mess.  Also, `Time.now` is now deprecated and may vanish in a newer version.

The actual breaking change (as in it would fail compiling) was that `Time#date` now returns a `Tuple(Int32, Int32, Int32)` instead of a `Time` object.  Therefore I replaced that with `Time#at_beginning_of_day` which returns a `Time` object, and everything is good again.  Yay!

See also: [Crystal 0.28.0 Release Notes#Time](https://crystal-lang.org/2019/04/17/crystal-0.28.0-released.html#time)