### PR TITLE
Update date to be compatible for 0.28.0

### DIFF
--- a/spec/stats_spec.cr
+++ b/spec/stats_spec.cr
@@ -14,8 +14,8 @@ describe Sidekiq::Stats do
     end
 
     it "returns correct data from redis" do
-      yesterday = (Time.now.to_utc.date - 1.day).to_s("%Y-%m-%d")
-      today = Time.now.to_utc.date.to_s("%Y-%m-%d")
+      yesterday = (Time.now.to_utc.at_beginning_of_day - 1.day).to_s("%Y-%m-%d")
+      today = Time.now.to_utc.at_beginning_of_day.to_s("%Y-%m-%d")
 
       Sidekiq.redis do |redis|
         redis.set("stat:failed:#{yesterday}", 42)

--- a/src/sidekiq/api.cr
+++ b/src/sidekiq/api.cr
@@ -145,7 +145,7 @@ module Sidekiq
 
       def initialize(days_previous, start_date = nil)
         @days_previous = days_previous
-        @start_date = start_date || Time.now.to_utc.date
+        @start_date = start_date || Time.now.to_utc.at_beginning_of_day
       end
 
       def processed


### PR DESCRIPTION
Time#date that will now return a Tuple of {year, month, day}. You can keep using Time#at_beginning_of_day if a Time instance is wanted. Read more at [#5822](https://github.com/crystal-lang/crystal/pull/5822).

