### PR TITLE
Update benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ give you options.  Ruby is friendly and flexible but not terribly fast.
 Crystal is statically-typed, compiled and **very fast** but retains a similar syntax to
 Ruby.
 
-Rough, initial benchmarks on OSX 10.11.5:
+Rough, initial benchmarks on macOS 10.14.5:
 
 Runtime | RSS | Time | Throughput
 --------|-----|------|-------------
-MRI 2.3.0 | 50MB | 21.3 | 4,600 jobs/sec
-MRI/hiredis | 55MB | 19.2 | 5,200 jobs/sec
-Crystal 0.18.4 | 12MB | 5.9 | 16,900 jobs/sec
+MRI 2.6.3 | 55MB | 11.1 | 9,000 jobs/sec
+MRI/hiredis | 62MB | 8.3 | 12,000 jobs/sec
+Crystal 0.29.0 | 15MB | 1.4 | 69,200 jobs/sec
 
 If you have jobs which are CPU-intensive or require very high throughput,
 Crystal is an excellent alternative to native Ruby extensions.  It


### PR DESCRIPTION
Ruby, Crystal, and macOS have all had significant changes since these benchmark results were written, so this commit brings them up-to-date with the latest Ruby, Crystal, and macOS.

The throughput numbers are more than doubled for each one, but that can also be attributed to differences in hardware in the past couple years since these benchmarks were written. The main difference that I wanted to highlight with this change is that the throughput ratio of Crystal to Ruby (even with HiRedis) has increased from 3.25x to 5.76x. I tried increasing the number of iterations but they didn't meaningfully change the results, so I left it at 100k.

Log snippets:

MRI 2.6.3, standard Redis driver:

```
2019-07-05T18:21:57.720Z 21858 TID-oxvnhjz9q ERROR: RSS: 55324 Pending: 0
2019-07-05T18:21:57.720Z 21858 TID-oxvnhjz9q ERROR: Done in 11.06437: 9038.021873459018 jobs/sec
```

MRI 2.6.3 with HiRedis:

```
2019-07-05T18:22:26.471Z 21934 TID-ow7c05gu2 ERROR: RSS: 62544 Pending: 0
2019-07-05T18:22:26.471Z 21934 TID-ow7c05gu2 ERROR: Done in 8.279566: 12077.930673644167 jobs/sec
```

Crystal 0.29.0:

```
[2019-07-05 14:23:20.358240000 -04:00 Local, 13576, 15152]
Done in 00:00:01.444737000: 69216.750 jobs/sec
```