### PR TITLE
Pipeline commands in Client#raw_push

### DIFF
--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -142,8 +142,10 @@ module Sidekiq
 
     def raw_push(payloads)
       @ctx.pool.redis do |conn|
-        conn.multi do |multi|
-          atomic_push(multi, payloads)
+        conn.pipelined do |pipeline|
+          pipeline.command ["MULTI"]
+          atomic_push(pipeline, payloads)
+          pipeline.command ["EXEC"]
         end
       end
       true


### PR DESCRIPTION
I may be totally missing the obvious here, but in experimenting with Sidekiq.cr vs. Sidekiq Ruby I noticed that Sidekiq's push was slower for me in Crystal than Ruby. This was noticeable because of the latency of the given remote Redis server (~40ms), which led to a ~140ms duration for Sidekiq::Client#push under Crystal; meanwhile, Ruby was clocking in at ~90ms. I was amazed at this, so I began to dig.

I noticed that under Ruby, Redis::Client#multi appeared to be utilising pipelining, whereas the Crystal client was apparently not. So I decided to try enclosing the push in a "pipelined" block and manually wrapping it with multi/exec and the results seem to reduce the whole operation to a single round trip. I appreciate that it has to be an atomic transaction, but is this approach flawed in some way?

Using the Redis "monitor" command, I produced this log showing the breakdown - https://gist.github.com/pgeraghty/bca2d92a69aaf6e2e9d23fd779edd14f - and this one showing the benchmark results (of 100 pushes) before and after - https://gist.github.com/pgeraghty/b2bf8d9bdc0d93167223b8df0967d397.