### PR TITLE
Fix broken dependencies

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -20,7 +20,7 @@ dependencies:
     branch: master
   kemal-session:
     github: kemalcr/kemal-session
-    commit: master
+    version: 0.12.0
   kemal-csrf:
     github: kemalcr/kemal-csrf
     version: 0.6.0

--- a/shard.yml
+++ b/shard.yml
@@ -20,7 +20,7 @@ dependencies:
     branch: master
   kemal-session:
     github: kemalcr/kemal-session
-    commit: a16f164d3dcfc6e720d566f9085285abdd5b7825
+    commit: master
   kemal-csrf:
     github: kemalcr/kemal-csrf
     version: 0.5.0

--- a/shard.yml
+++ b/shard.yml
@@ -23,7 +23,7 @@ dependencies:
     commit: master
   kemal-csrf:
     github: kemalcr/kemal-csrf
-    version: 0.5.0
+    version: 0.6.0
   baked_file_system:
     github: schovi/baked_file_system
     version: ~> 0.9.5


### PR DESCRIPTION
This pull request resolves a dependency problem (more specifically `kemal-session`) which prevents `shard update` to install all dependencies.
Fixes #88.