### PR TITLE
Remove hack to disable banner on tests.

### DIFF
--- a/src/sidekiq/server/cli.cr
+++ b/src/sidekiq/server/cli.cr
@@ -58,7 +58,6 @@ module Sidekiq
     def run(svr)
       logger.info { "Sidekiq v#{Sidekiq::VERSION} in Crystal #{Crystal::VERSION}" }
       logger.info { Sidekiq::LICENSE }
-      logger.info { "Upgrade to Sidekiq Enterprise for more features and support: https://sidekiq.org" }
       logger.info { "Starting processing with #{@concurrency} workers" }
 
       logger.debug { self.inspect }

--- a/src/sidekiq/server/cli.cr
+++ b/src/sidekiq/server/cli.cr
@@ -56,8 +56,6 @@ module Sidekiq
     end
 
     def run(svr)
-      # hack to avoid printing banner in test suite
-      print_banner if logger == @logger
       logger.info { "Sidekiq v#{Sidekiq::VERSION} in Crystal #{Crystal::VERSION}" }
       logger.info { Sidekiq::LICENSE }
       logger.info { "Upgrade to Sidekiq Enterprise for more features and support: https://sidekiq.org" }


### PR DESCRIPTION
No log output is show anymore on tests since tests are using `Log::MemoryBackend`.