### PR TITLE
Fix regression on retry jobs after a4b6384220256704d1b045bea057dbdd00ca6f0d

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -34,3 +34,8 @@ dependencies:
   db:
     github: crystal-lang/crystal-db
     version: "~> 0.10.0"
+
+development_dependencies:
+  timecop:
+    github: crystal-community/timecop.cr
+    version: ~> 0.4.1

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,8 @@
 require "spec"
+require "timecop"
 require "../src/sidekiq"
+
+Timecop.safe_mode = true
 
 # FIXME: spec/web_spec.cr and spec/scheduled_spec.cr are requiring 2 redis connections.
 POOL = Sidekiq::Pool.new(2)

--- a/src/sidekiq/server/retry_jobs.cr
+++ b/src/sidekiq/server/retry_jobs.cr
@@ -95,7 +95,8 @@ module Sidekiq
 
         job.error_message = exception.message
         job.error_class = exception.class.name
-        job.failed_at = Time.local
+        job.failed_at = Time.local if job.retry_count.zero?
+        job.retried_at = Time.local
         count = job.retry_count += 1
 
         tcount = traces(job.backtrace)


### PR DESCRIPTION
- Correctly set retried_at and failed_at fields.
- Add timecop development dependency to test job retries.

Issue found at https://github.com/mperham/sidekiq.cr/commit/a4b6384220256704d1b045bea057dbdd00ca6f0d#r48541525