### PR TITLE
Bumps Kemal 1.0.0 -> 1.3.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
     version: ~> 2.6
   kemal:
     github: kemalcr/kemal
-    version: "~> 1.0.0"
+    version: "~> 1.3.0"
   kemal-session:
     github: kemalcr/kemal-session
     version: "~> 1.0.0"


### PR DESCRIPTION
Out of the box, I encountered the following message after creating a copy of the provided example for `web.cr`

```
$ crystal build --release web.cr
Showing last frame. Use --error-trace for full trace.

In lib/kemal/src/kemal/static_file_handler.cr:55:25

 55 | last_modified = modification_time(file_path)
                      ^----------------
```

It probably has to do with [modification_time being a private method?](https://github.com/kemalcr/kemal/blob/ae7cda829162ea27668b3fc79cd1868026e25098/src/kemal/static_file_handler.cr#L79). Anyway, after forking the project and changing Kemal's target version the web UI file compiled without problems.

Might also want to change the instructions, as they instruct to compile it with `crystal compile` but the new command is `crystal build`.