### PR TITLE
Swap to a more optimized Redis client

### DIFF
--- a/bench/load.cr
+++ b/bench/load.cr
@@ -18,7 +18,7 @@ require "../src/sidekiq/server/cli"
 puts "Compiled with #{{{`crystal -v`.stringify}}}"
 puts "Running on #{`uname -a`}"
 
-r = Redis.new
+r = Redis::Client.new
 r.flushdb
 
 s = Sidekiq::CLI.new

--- a/examples/sidekiq.cr
+++ b/examples/sidekiq.cr
@@ -19,7 +19,7 @@ class CrystalWorker
 end
 
 class SomeClientMiddleware < Sidekiq::Middleware::ClientEntry
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     ctx.logger.info { "Pushing job #{job.jid}" }
     yield
     true
@@ -27,7 +27,7 @@ class SomeClientMiddleware < Sidekiq::Middleware::ClientEntry
 end
 
 class SomeServerMiddleware < Sidekiq::Middleware::ServerEntry
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     ctx.logger.info { "Executing job #{job.jid}" }
     yield
     true

--- a/shard.yml
+++ b/shard.yml
@@ -10,8 +10,8 @@ crystal: ">= 1.6.0"
 
 dependencies:
   redis:
-    github: stefanwille/crystal-redis
-    version: ">= 2.6"
+    github: jgaskins/redis
+    branch: master
   kemal:
     github: kemalcr/kemal
     version: ">= 1.3.0"

--- a/spec/api_spec.cr
+++ b/spec/api_spec.cr
@@ -19,7 +19,7 @@ describe "api" do
 
     describe "processed" do
       it "returns number of processed jobs" do
-        Sidekiq.redis { |conn| conn.set("stat:processed", 5) }
+        Sidekiq.redis { |conn| conn.set("stat:processed", "5") }
         s = Sidekiq::Stats.new
         s.processed.should eq(5)
       end
@@ -27,7 +27,7 @@ describe "api" do
 
     describe "failed" do
       it "returns number of failed jobs" do
-        Sidekiq.redis { |conn| conn.set("stat:failed", 5) }
+        Sidekiq.redis { |conn| conn.set("stat:failed", "5") }
         s = Sidekiq::Stats.new
         s.failed.should eq(5)
       end
@@ -256,7 +256,7 @@ describe "api" do
       Sidekiq.redis do |conn|
         conn.multi do |m|
           m.sadd("processes", odata["key"].to_s)
-          m.hmset(odata["key"].as_s, {"info" => odata.to_json, "busy" => 10, "beat" => time})
+          m.hset(odata["key"].as_s, {"info" => odata.to_json, "busy" => "10", "beat" => time.to_s})
           m.sadd("processes", "fake:pid")
         end
       end
@@ -283,13 +283,13 @@ describe "api" do
       pdata = {"pid" => Process.pid, "hostname" => hn, "started_at" => Time.local.to_unix}
       Sidekiq.redis do |conn|
         conn.sadd("processes", key)
-        conn.hmset(key, {"info" => pdata.to_json, "busy" => 0, "beat" => Time.local.to_unix_f})
+        conn.hset(key, {"info" => pdata.to_json, "busy" => "0", "beat" => Time.local.to_unix_f.to_s})
       end
 
       s = "#{key}:workers"
       data = {"payload" => "{}", "queue" => "default", "run_at" => Time.local.to_unix}.to_json
       Sidekiq.redis do |c|
-        c.hmset(s, {"1234" => data})
+        c.hset(s, {"1234" => data})
       end
 
       count = 0
@@ -324,7 +324,7 @@ describe "api" do
       key = "#{data["hostname"]}:#{data["pid"]}"
       Sidekiq.redis do |conn|
         conn.sadd("processes", key)
-        conn.hmset(key, {"info" => data.to_json, "busy" => 0, "beat" => Time.local.to_unix_f})
+        conn.hset(key, {"info" => data.to_json, "busy" => "0", "beat" => Time.local.to_unix_f.to_s})
       end
 
       ps = Sidekiq::ProcessSet.new
@@ -353,7 +353,7 @@ end
 
 def reset_stats
   Sidekiq.redis do |conn|
-    conn.set("stat:processed", 5)
-    conn.set("stat:failed", 10)
+    conn.set("stat:processed", "5")
+    conn.set("stat:failed", "10")
   end
 end

--- a/spec/middleware_spec.cr
+++ b/spec/middleware_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 class SomeMiddleware < Sidekiq::Middleware::ClientEntry
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     ctx.logger.info { "start" }
     yield
     ctx.logger.info { "done" }
@@ -10,7 +10,7 @@ class SomeMiddleware < Sidekiq::Middleware::ClientEntry
 end
 
 class StopperMiddleware < Sidekiq::Middleware::ClientEntry
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     if false
       yield
     else
@@ -25,7 +25,7 @@ class ExtraParamsClientMiddleware < Sidekiq::Middleware::ClientEntry
   def initialize(@extra_params)
   end
 
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     job.extra_params = @extra_params
     yield
     true
@@ -35,7 +35,7 @@ end
 class ExtraParamsServerMiddleware < Sidekiq::Middleware::ServerEntry
   getter extra_params = Hash(String, JSON::Any).new
 
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     @extra_params = job.extra_params
     yield
     true

--- a/spec/server_spec.cr
+++ b/spec/server_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 require "../src/sidekiq/server"
 
 class Foo < Sidekiq::Middleware::ServerEntry
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     yield
   end
 end

--- a/spec/sidekiq_spec.cr
+++ b/spec/sidekiq_spec.cr
@@ -18,20 +18,6 @@ describe Sidekiq do
     end
   end
 
-  describe "pool" do
-    it "works" do
-      t = Time.local
-      pool = ConnectionPool.new { Redis.new }
-      pool.connection do |conn|
-        conn.set("foo", t)
-      end
-      result = pool.connection do |conn|
-        conn.get("foo")
-      end
-      result.should eq(t.to_s)
-    end
-  end
-
   describe "redis pooling" do
     it "works" do
       r = Sidekiq::Pool.new(1)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -37,9 +37,9 @@ def requires_redis(op, ver, &block)
   redis_version = POOL.redis { |c| c.info["redis_version"] }.as(String)
 
   proc = if op == :<
-           ->{ redis_version < ver }
+           -> { redis_version < ver }
          elsif op == :>=
-           ->{ redis_version >= ver }
+           -> { redis_version >= ver }
          else
            raise "No such op: #{op}"
          end

--- a/spec/stats_spec.cr
+++ b/spec/stats_spec.cr
@@ -18,8 +18,8 @@ describe Sidekiq::Stats do
       today = Time.utc.at_beginning_of_day.to_s("%Y-%m-%d")
 
       Sidekiq.redis do |redis|
-        redis.set("stat:failed:#{yesterday}", 42)
-        redis.set("stat:processed:#{yesterday}", 120)
+        redis.set("stat:failed:#{yesterday}", "42")
+        redis.set("stat:processed:#{yesterday}", "120")
       end
 
       stats_history = Sidekiq::Stats::History.new(2)

--- a/src/sidekiq.cr
+++ b/src/sidekiq.cr
@@ -11,7 +11,7 @@ module Sidekiq
   NAME    = "Sidekiq"
   LICENSE = "Licensed for use under the terms of the GNU LGPL-3.0 license."
 
-  def self.redis
+  def self.redis(&)
     Sidekiq::Client.default_context.pool.redis do |conn|
       yield conn
     end

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -151,7 +151,7 @@ module Sidekiq
 
     def atomic_push(conn, payloads)
       if payloads.first.at
-        all = [] of Redis::RedisValue
+        all = [] of String
         payloads.each do |hash|
           at, hash.at = hash.at, nil
           all << at.not_nil!.to_unix_f.to_s

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -51,7 +51,7 @@ module Sidekiq
     #     chain.use MyClientMiddleware
     #   end
     #
-    def middleware
+    def middleware(&)
       yield @chain
       @chain
     end

--- a/src/sidekiq/server/cli.cr
+++ b/src/sidekiq/server/cli.cr
@@ -43,7 +43,7 @@ module Sidekiq
       Sidekiq::Server.new(concurrency: @concurrency, queues: @queues, logger: logger)
     end
 
-    def configure(logger = @logger)
+    def configure(logger = @logger, &)
       x = create(logger)
       yield x
       Sidekiq::Client.default_context = Sidekiq::Client::Context.new(pool: x.pool, logger: x.logger)

--- a/src/sidekiq/server/fetch.cr
+++ b/src/sidekiq/server/fetch.cr
@@ -50,7 +50,7 @@ module Sidekiq
     end
 
     def retrieve_work(ctx) : Sidekiq::UnitOfWork?
-      arr = ctx.pool.redis(&.brpop(@queues, TIMEOUT)).as(Array(Redis::RedisValue))
+      arr = ctx.pool.redis(&.brpop(@queues, TIMEOUT)).as(Array)
       if arr.size == 2
         UnitOfWork.new(arr[0].to_s, arr[1].to_s, ctx)
       end
@@ -80,7 +80,7 @@ module Sidekiq
 
       count = 0
       ctx.pool.redis do |conn|
-        conn.pipelined do |pipeline|
+        conn.pipeline do |pipeline|
           jobs_to_requeue.each do |queue, jobs|
             jobs.each do |job|
               # Crystal-Redis sends array as one value, we are unable to do rpush("queue", jobs)

--- a/src/sidekiq/server/heartbeat.cr
+++ b/src/sidekiq/server/heartbeat.cr
@@ -77,10 +77,10 @@ module Sidekiq
         _, _, _, msg = svr.pool.redis do |conn|
           conn.multi do |multi|
             multi.sadd("processes", svr.identity)
-            multi.hmset(svr.identity, {"info"  => json,
-                                       "busy"  => Processor.worker_state.size,
-                                       "beat"  => Time.local.to_unix_f,
-                                       "quiet" => svr.stopping?})
+            multi.hset(svr.identity, {"info"  => json,
+                                      "busy"  => Processor.worker_state.size.to_s,
+                                      "beat"  => Time.local.to_unix_f.to_s,
+                                      "quiet" => svr.stopping?.to_s})
             multi.expire(svr.identity, 60)
             multi.rpop("#{svr.identity}-signals")
           end

--- a/src/sidekiq/server/middleware.cr
+++ b/src/sidekiq/server/middleware.cr
@@ -3,7 +3,7 @@ require "../middleware"
 require "./retry_jobs"
 
 class Sidekiq::Middleware::Logger < Sidekiq::Middleware::ServerEntry
-  def call(job, ctx) : Bool
+  def call(job, ctx, &) : Bool
     ctx.logger.info &.emit("Start", jid: job.jid)
     time = Benchmark.realtime { yield }.to_f.format(decimal_places: 6)
     ctx.logger.info &.emit("Done: #{time} sec", JID: job.jid)

--- a/src/sidekiq/server/processor.cr
+++ b/src/sidekiq/server/processor.cr
@@ -138,7 +138,7 @@ module Sidekiq
       @@failure += f
     end
 
-    def stats(job)
+    def stats(job, &)
       @@worker_state[@identity] = {"queue" => job.queue, "payload" => job, "run_at" => Time.local.to_unix}
 
       yield

--- a/src/sidekiq/server/processor.cr
+++ b/src/sidekiq/server/processor.cr
@@ -86,7 +86,7 @@ module Sidekiq
         @down = Time.local
         @mgr.logger.error(exception: ex) { "Error fetching job: #{ex}" }
       end
-      sleep(1)
+      sleep(1.second)
     end
 
     private def process(work)

--- a/src/sidekiq/server/retry_jobs.cr
+++ b/src/sidekiq/server/retry_jobs.cr
@@ -59,7 +59,7 @@ module Sidekiq
         @max_retries = DEFAULT_MAX_RETRY_ATTEMPTS
       end
 
-      def call(job, ctx) : Bool
+      def call(job, ctx, &) : Bool
         yield
         true
       rescue e : Exception

--- a/src/sidekiq/server/retry_jobs.cr
+++ b/src/sidekiq/server/retry_jobs.cr
@@ -131,7 +131,7 @@ module Sidekiq
         ctx.pool.redis do |conn|
           conn.multi do
             conn.zadd("dead", now.to_unix_f.to_s, payload)
-            conn.zremrangebyscore("dead", "-inf", now - 6.months)
+            conn.zremrangebyscore("dead", "-inf", (now - 6.months).to_unix_f)
             conn.zremrangebyrank("dead", 0, -10_000)
           end
         end

--- a/src/sidekiq/server/scheduled.cr
+++ b/src/sidekiq/server/scheduled.cr
@@ -17,7 +17,7 @@ module Sidekiq
             # going wrong between the time jobs are popped from the scheduled queue and when
             # they are pushed onto a work queue and losing the jobs.
             loop do
-              results = conn.zrangebyscore(sorted_set, "-inf", nowstr, limit: [0, 1]).as(Array)
+              results = conn.zrangebyscore(sorted_set, "-inf", nowstr, limit: {"0", "1"}).as(Array)
               break if results.empty?
               jobstr = results[0].as(String)
               job = Sidekiq::Job.from_json(jobstr)

--- a/src/sidekiq/server/util.cr
+++ b/src/sidekiq/server/util.cr
@@ -9,7 +9,7 @@ module Sidekiq
 
     EXPIRY = 60 * 60 * 24
 
-    def watchdog(ctx, last_words)
+    def watchdog(ctx, last_words, &)
       yield
     rescue ex : Exception
       handle_exception(ctx, ex, {"context" => JSON::Any.new(last_words)})

--- a/src/sidekiq/web_helpers.cr
+++ b/src/sidekiq/web_helpers.cr
@@ -78,7 +78,7 @@ module Sidekiq
     end
 
     def redis_location
-      Sidekiq.redis(&.url)
+      Sidekiq.redis(&.uri)
     end
 
     def redis_info
@@ -204,9 +204,9 @@ module Sidekiq
           total_size, items = conn.multi do |m|
             m.zcard(key)
             if rev
-              m.zrevrange(key, starting, ending, {"with_scores": true})
+              m.zrevrange(key, starting.to_s, ending.to_s, with_scores: true)
             else
-              m.zrange(key, starting, ending, {"with_scores": true})
+              m.zrange(key, starting, ending, with_scores: true)
             end
           end
           [current_page, total_size, items]

--- a/src/sidekiq/worker.cr
+++ b/src/sidekiq/worker.cr
@@ -118,7 +118,7 @@ module Sidekiq
       end
 
       # if passed a block, yields the job
-      def async
+      def async(&)
         {% begin %}
         job = ::{{@type.id}}::PerformProxy.new
         job.klass = self.name


### PR DESCRIPTION
The `stefanwille/crystal-redis` shard is fast but surprisingly wasteful, as you can see in the benchmark results below. On the other hand, [my Redis shard](https://github.com/jgaskins/redis) was designed from the ground up to be as lightweight as possible. It actually began as an attempt to optimize the other shard but ended up being difficult to optimize and, in order to get the most out of it, required an entirely different architecture to play to Crystal's strengths.

The result of this change in Redis client is a roughly 25% increase in throughput according to [`bench/load.cr`](https://github.com/hugopl/sidekiq.cr/blob/f769649e009e4d42f8f41bda25b7bc02d538a0ca/bench/load.cr). This is inclusive of TCP round trips, whose latency does not appear to change notably with client implementation, so the delta in CPU time is almost guaranteed to be significantly higher than 25%.

These times are measured on an M4 MacBook Pro.

### Before

```
Done in 00:00:01.038106000: 96329.277 jobs/sec
```

### After

```
Done in 00:00:00.830465000: 120414.467 jobs/sec
```

This is a Redis client that outperforms the `redis-rs` Rust crate by a factor of [2.3-3.1x](https://dev.to/jgaskins/performance-comparison-rust-vs-crystal-with-redis-1a17).

## Implementation Notes

This required a handful of very small changes to accommodate differences in APIs between the `stefanwille/crystal-redis` and `jgaskins/redis` shards. All of the changes are basically along these lines:

- `hmset` takes a strict `Hash(String, String)` instead of any old hash
- The `HMSET` command is deprecated in the Redis server and we should be using the `HSET` command instead anyway, but the same args apply
- `set` takes a strict `String` value argument
- No need for `ConnectionPool` because `Redis::Client` already wraps a `DB::Pool(Redis::Connection)`, which is more robust than `ConnectionPool`
- The `piplined` method is called `pipeline`
- The `Redis::RedisValue` type becomes `Redis::Value`

I actually first did this port several years ago, but I spoke to Mike Perham about it at a conference and he said he wasn't going to be maintaining this shard due to a change of focus on polyglot background jobs, so I never opened the PR. I saw the shard had changed ownership so I thought I'd check to see if you were open to it.