### PR TITLE
Add Sidekiq.testing and Sidekiq::TestMode for inline job execution in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,40 @@ compiles to a single executable so deployment is much easier than Ruby.
 Please see the [wiki](https://github.com/hugopl/sidekiq.cr/wiki) for in-depth documentation and how to get
 started using Sidekiq.cr in your own app.
 
+## Testing
+
+`require "sidekiq/testing"` in your spec helper to enable `Sidekiq.testing`, which
+lets you control how jobs behave when pushed from specs instead of always hitting Redis.
+
+```crystal
+require "sidekiq/testing"
+
+Sidekiq.testing(Sidekiq::TestMode::Inline)
+
+HardWorker.async.perform(1_i64)
+```
+
+`Sidekiq::TestMode` has two values:
+
+* `Disable` - the default, Sidekiq behaves normally and jobs are pushed to Redis.
+* `Inline` - jobs are executed synchronously, in-process, the moment they are
+  pushed instead of being enqueued in Redis. It doesn't make sense to use
+  `perform_at`/`perform_in` while `Inline` is active, doing so raises an exception.
+
+`Sidekiq.testing` also accepts a block, in which case the mode is only active for the
+duration of the block and whatever mode was active before is restored afterwards:
+
+```crystal
+Sidekiq.testing(Sidekiq::TestMode::Inline) do
+  HardWorker.async.perform(1_i64)
+end
+```
+
+> [!WARNING]
+> `Sidekiq.test_mode` is a single, process-wide flag and mutating it isn't thread-safe.
+> Don't run specs that rely on it concurrently across fibers/threads (e.g. with `-Dpreview_mt`
+> or a parallel spec runner), or one spec's mode can leak into another's.
+
 ## Support
 
 Sidekiq.cr is community-supported and **not** commercially supported by @mperham and Contributed Systems.

--- a/spec/testing_spec.cr
+++ b/spec/testing_spec.cr
@@ -1,0 +1,86 @@
+require "./spec_helper"
+require "../src/sidekiq/testing"
+
+class TestingWorker
+  include Sidekiq::Worker
+
+  @@performed = [] of String
+
+  def self.performed
+    @@performed
+  end
+
+  def self.reset
+    @@performed = [] of String
+  end
+
+  def perform(msg : String)
+    @@performed << msg
+  end
+end
+
+Spec.after_each do
+  Sidekiq.test_mode = :disable
+  TestingWorker.reset
+end
+
+describe "Sidekiq.testing" do
+  it "defaults to Disable, i.e. normal behavior, pushing to Redis" do
+    Sidekiq.test_mode.should eq(Sidekiq::TestMode::Disable)
+
+    TestingWorker.async.perform("hello")
+
+    TestingWorker.performed.should be_empty
+    POOL.redis(&.llen("queue:default")).should eq(1)
+  end
+
+  it "runs jobs inline instead of pushing to Redis when set to Inline" do
+    Sidekiq.testing(Sidekiq::TestMode::Inline)
+
+    TestingWorker.async.perform("hello")
+
+    TestingWorker.performed.should eq(["hello"])
+    POOL.redis(&.llen("queue:default")).should eq(0)
+  end
+
+  it "runs bulk jobs inline instead of pushing to Redis when set to Inline" do
+    Sidekiq.testing(Sidekiq::TestMode::Inline)
+
+    TestingWorker.async.perform_bulk([{"a"}, {"b"}, {"c"}])
+
+    TestingWorker.performed.should eq(["a", "b", "c"])
+    POOL.redis(&.llen("queue:default")).should eq(0)
+  end
+
+  it "runs the block in Inline mode and restores the previous mode afterwards" do
+    Sidekiq.testing(Sidekiq::TestMode::Inline) do
+      Sidekiq.test_mode.should eq(Sidekiq::TestMode::Inline)
+      TestingWorker.async.perform("block")
+    end
+
+    Sidekiq.test_mode.should eq(Sidekiq::TestMode::Disable)
+    TestingWorker.performed.should eq(["block"])
+  end
+
+  it "restores a previously active (non-default) mode after the block form returns" do
+    Sidekiq.testing(Sidekiq::TestMode::Inline)
+
+    Sidekiq.testing(Sidekiq::TestMode::Disable) do
+      TestingWorker.async.perform("nested")
+    end
+
+    Sidekiq.test_mode.should eq(Sidekiq::TestMode::Inline)
+    TestingWorker.performed.should be_empty
+    POOL.redis(&.llen("queue:default")).should eq(1)
+  end
+
+  it "raises when a scheduled job (perform_at/perform_in) is pushed in Inline mode" do
+    Sidekiq.testing(Sidekiq::TestMode::Inline)
+
+    expect_raises(Exception, /does not make sense with perform_at\/perform_in/) do
+      TestingWorker.async.perform_in(1.hour, "later")
+    end
+
+    TestingWorker.performed.should be_empty
+  end
+end

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -118,7 +118,18 @@ module Sidekiq
     # Returns an array of the of pushed jobs' jids.  The number of jobs pushed can be less
     # than the number given if the middleware stopped processing for one or more jobs.
     def push_bulk(job : Sidekiq::Job, allargs : Array(String))
-      payloads = allargs.compact_map do |args|
+      payloads = build_bulk_payloads(job, allargs)
+
+      raw_push(payloads) if !payloads.empty?
+      payloads.map(&.jid)
+    end
+
+    # #
+    # Builds one Sidekiq::Job copy per element of +allargs+, running each
+    # through the client middleware pipeline. Shared by #push_bulk and by
+    # Sidekiq::TestMode's inline push_bulk override.
+    private def build_bulk_payloads(job : Sidekiq::Job, all_args : Array(String))
+      all_args.compact_map do |args|
         copy = Sidekiq::Job.new
         copy.jid = Random::Secure.hex(12)
         copy.klass = job.klass
@@ -130,9 +141,6 @@ module Sidekiq
         end
         result ? copy : nil
       end
-
-      raw_push(payloads) if !payloads.empty?
-      payloads.map(&.jid)
     end
 
     def raw_push(payloads)

--- a/src/sidekiq/testing.cr
+++ b/src/sidekiq/testing.cr
@@ -1,0 +1,85 @@
+require "../sidekiq"
+
+# #
+# Require "sidekiq/testing" in your spec_helper (or similar) to enable
+# `Sidekiq.testing`.  This monkey patches `Sidekiq::Client` so jobs
+# pushed while `Sidekiq::TestMode::Inline` is active don't hit Redis
+# at all, they run synchronously instead.
+#
+#   require "sidekiq/testing"
+#
+#   Sidekiq.testing(Sidekiq::TestMode::Inline)
+#
+module Sidekiq
+  # #
+  # Disable - the default. Sidekiq behaves normally: jobs are pushed to Redis.
+  # Inline  - jobs are executed synchronously, in-process, the moment
+  #           they are pushed instead of being enqueued in Redis.
+  enum TestMode
+    Disable
+    Inline
+  end
+
+  class_property test_mode : Sidekiq::TestMode = Sidekiq::TestMode::Disable
+
+  # #
+  # Sets the Sidekiq test mode globally, until changed again.
+  #
+  #   Sidekiq.testing(Sidekiq::TestMode::Inline)
+  #
+  def self.testing(mode : Sidekiq::TestMode) : Nil
+    self.test_mode = mode
+  end
+
+  # #
+  # Sets the Sidekiq test mode for the duration of the block, restoring
+  # whatever mode was previously active once the block returns.
+  #
+  #   Sidekiq.testing(Sidekiq::TestMode::Inline) do
+  #     HardWorker.async.perform(1_i64)
+  #   end
+  #
+  def self.testing(mode : Sidekiq::TestMode, &)
+    previous_mode = test_mode
+    self.test_mode = mode
+    begin
+      yield
+    ensure
+      self.test_mode = previous_mode
+    end
+  end
+
+  class Client
+    def push(job : Sidekiq::Job)
+      return previous_def if Sidekiq.test_mode.disable?
+
+      if job.at
+        raise "Sidekiq.testing(Inline) does not make sense with perform_at/perform_in: " \
+              "#{job.klass} was scheduled for #{job.at}, but inline mode always runs jobs immediately"
+      end
+
+      result = middleware.invoke(job, @ctx) { true }
+      return nil unless result
+
+      # `execute` relies on `Job.@@jobtypes`, a class variable that Crystal
+      # scopes per-subclass rather than sharing across the hierarchy (unlike
+      # Ruby). `job` here is a Worker-specific `PerformProxy < Job`, so it
+      # must be round-tripped through JSON into a plain `Job` first, exactly
+      # like the real Redis-backed path does.
+      Sidekiq::Job.from_json(job.to_json).execute(@ctx)
+      job.jid
+    end
+
+    def push_bulk(job : Sidekiq::Job, allargs : Array(String))
+      return previous_def if Sidekiq.test_mode.disable?
+
+      payloads = build_bulk_payloads(job, allargs)
+
+      # Unlike `push`, `copy` here is already a plain `Sidekiq::Job` (built
+      # via `Sidekiq::Job.new` in `build_bulk_payloads`), not a Worker-specific
+      # `PerformProxy`, so it can be executed directly without a JSON round-trip.
+      payloads.each(&.execute(@ctx))
+      payloads.map(&.jid)
+    end
+  end
+end


### PR DESCRIPTION
… specs

Requiring "sidekiq/testing" monkey patches Client#push/#push_bulk so jobs run synchronously in-process (TestMode::Inline) instead of hitting Redis, while TestMode::Disable (the default) keeps normal behavior. A block form of Sidekiq.testing restores whatever mode was active before.

Fixes #86